### PR TITLE
Split ConfigBodyPost structure

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -8,24 +8,27 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func GetConfigSystem(d *schema.ResourceData) models.ConfigBodyPost {
-	return models.ConfigBodyPost{
+func GetConfigSystem(d *schema.ResourceData) models.ConfigBodySystemPost {
+	var body models.ConfigBodySystemPost
+	body = models.ConfigBodySystemPost{
 		ProjectCreationRestriction: d.Get("project_creation_restriction").(string),
 		ReadOnly:                   d.Get("read_only").(bool),
 		RobotTokenDuration:         d.Get("robot_token_expiration").(int),
 		QuotaPerProjectEnable:      true,
 		RobotNamePrefix:            d.Get("robot_name_prefix").(string),
 	}
+	log.Printf("[DEBUG] %+v\n ", body)
+	return body
 }
 
-func GetConfigAuth(d *schema.ResourceData) models.ConfigBodyPost {
-	var body models.ConfigBodyPost
+func GetConfigAuth(d *schema.ResourceData) models.ConfigBodyAuthPost {
+	var body models.ConfigBodyAuthPost
 
 	auth := d.Get("auth_mode").(string)
 
 	switch auth {
 	case "oidc_auth", "oidc":
-		body = models.ConfigBodyPost{
+		body = models.ConfigBodyAuthPost{
 			AuthMode:         "oidc_auth",
 			OidcName:         d.Get("oidc_name").(string),
 			OidcEndpoint:     d.Get("oidc_endpoint").(string),
@@ -39,22 +42,20 @@ func GetConfigAuth(d *schema.ResourceData) models.ConfigBodyPost {
 			OidcAdminGroup:   d.Get("oidc_admin_group").(string),
 		}
 	case "ldap_auth", "ldap":
-		body = models.ConfigBodyPost{
-			AuthMode:           "ldap_auth",
-			LdapURL:            d.Get("ldap_url").(string),
-			LdapSearchDn:       d.Get("ldap_search_dn").(string),
-			LdapSearchPassword: d.Get("ldap_search_password").(string),
-			LdapBaseDn:         d.Get("ldap_base_dn").(string),
-			LdapFilter:         d.Get("ldap_filter").(string),
-			LdapUID:            d.Get("ldap_uid").(string),
-
+		body = models.ConfigBodyAuthPost{
+			AuthMode:                     "ldap_auth",
+			LdapURL:                      d.Get("ldap_url").(string),
+			LdapSearchDn:                 d.Get("ldap_search_dn").(string),
+			LdapSearchPassword:           d.Get("ldap_search_password").(string),
+			LdapBaseDn:                   d.Get("ldap_base_dn").(string),
+			LdapFilter:                   d.Get("ldap_filter").(string),
+			LdapUID:                      d.Get("ldap_uid").(string),
 			LdapGroupBaseDn:              d.Get("ldap_group_base_dn").(string),
 			LdapGroupSearchFilter:        d.Get("ldap_group_filter").(string),
 			LdapGroupAttributeName:       d.Get("ldap_group_gid").(string),
 			LdapGroupAdminDn:             d.Get("ldap_group_admin_dn").(string),
 			LdapGroupMembershipAttribute: d.Get("ldap_group_membership").(string),
-
-			LdapVerifyCert: d.Get("ldap_verify_cert").(bool),
+			LdapVerifyCert:               d.Get("ldap_verify_cert").(bool),
 		}
 
 		ldapScope := d.Get("ldap_scope").(string)
@@ -72,8 +73,9 @@ func GetConfigAuth(d *schema.ResourceData) models.ConfigBodyPost {
 	return body
 }
 
-func GetConfigEmail(d *schema.ResourceData) models.ConfigBodyPost {
-	return models.ConfigBodyPost{
+func GetConfigEmail(d *schema.ResourceData) models.ConfigBodyEmailPost {
+	var body models.ConfigBodyEmailPost
+	body = models.ConfigBodyEmailPost{
 		EmailHost:     d.Get("email_host").(string),
 		EmailPort:     d.Get("email_port").(int),
 		EmailUsername: d.Get("email_username").(string),
@@ -82,6 +84,8 @@ func GetConfigEmail(d *schema.ResourceData) models.ConfigBodyPost {
 		EmailSsl:      d.Get("email_ssl").(bool),
 		EmailInsecure: d.Get("email_insecure").(bool),
 	}
+	log.Printf("[DEBUG] %+v\n ", body)
+	return body
 }
 
 func days2mins(days int) int {

--- a/models/config.go
+++ b/models/config.go
@@ -2,57 +2,62 @@ package models
 
 var PathConfig = "/configurations"
 
-type ConfigBodyPost struct {
-	OidcVerifyCert                  bool   `json:"oidc_verify_cert"`
-	OidcAutoOnboard                 bool   `json:"oidc_auto_onboard"`
-	OidcUserClaim                   string `json:"oidc_user_claim,omitempty"`
-	EmailIdentity                   string `json:"email_identity,omitempty"`
-	LdapGroupSearchFilter           string `json:"ldap_group_search_filter,omitempty"`
-	AuthMode                        string `json:"auth_mode,omitempty"`
-	SelfRegistration                bool   `json:"self_registration"`
-	OidcScope                       string `json:"oidc_scope,omitempty"`
-	LdapSearchDn                    string `json:"ldap_search_dn,omitempty"`
-	StoragePerProject               string `json:"storage_per_project,omitempty"`
-	ScanAllPolicy                   struct {
+type ConfigBodyAuthPost struct {
+	OidcVerifyCert        bool   `json:"oidc_verify_cert"`
+	OidcAutoOnboard       bool   `json:"oidc_auto_onboard"`
+	OidcUserClaim         string `json:"oidc_user_claim,omitempty"`
+	LdapGroupSearchFilter string `json:"ldap_group_search_filter,omitempty"`
+	AuthMode              string `json:"auth_mode,omitempty"`
+	SelfRegistration      bool   `json:"self_registration"`
+	OidcScope             string `json:"oidc_scope,omitempty"`
+	LdapSearchDn          string `json:"ldap_search_dn,omitempty"`
+	ScanAllPolicy         struct {
 		Type      string `json:"type,omitempty"`
 		Parameter struct {
 			DailyTime int `json:"daily_time,omitempty"`
 		} `json:"parameter,omitempty"`
 	} `json:"scan_all_policy,omitempty"`
-	LdapTimeout                     int    `json:"ldap_timeout,omitempty"`
-	LdapBaseDn                      string `json:"ldap_base_dn,omitempty"`
-	LdapFilter                      string `json:"ldap_filter,omitempty"`
-	ReadOnly                        bool   `json:"read_only"`
-	QuotaPerProjectEnable           bool   `json:"quota_per_project_enable"`
-	LdapURL                         string `json:"ldap_url,omitempty"`
-	OidcName                        string `json:"oidc_name,omitempty"`
-	ProjectCreationRestriction      string `json:"project_creation_restriction,omitempty"`
-	LdapUID                         string `json:"ldap_uid,omitempty"`
-	OidcClientID                    string `json:"oidc_client_id,omitempty"`
-	LdapGroupBaseDn                 string `json:"ldap_group_base_dn,omitempty"`
-	LdapGroupAttributeName          string `json:"ldap_group_attribute_name,omitempty"`
-	LdapGroupMembershipAttribute    string `json:"ldap_group_membership_attribute,omitempty"`
-	LdapSearchPassword              string `json:"ldap_search_password,omitempty"`
-	EmailInsecure                   bool   `json:"email_insecure"`
-	LdapGroupAdminDn                string `json:"ldap_group_admin_dn,omitempty"`
-	EmailUsername                   string `json:"email_username,omitempty"`
-	EmailPassword                   string `json:"email_password,omitempty"`
-	OidcEndpoint                    string `json:"oidc_endpoint,omitempty"`
-	OidcClientSecret                string `json:"oidc_client_secret,omitempty"`
-	OidcGroupsClaim                 string `json:"oidc_groups_claim,omitempty"`
-	LdapScope                       int    `json:"ldap_scope,omitempty"`
-	CountPerProject                 string `json:"count_per_project,omitempty"`
-	TokenExpiration                 int    `json:"token_expiration,omitempty"`
-	LdapGroupSearchScope            int    `json:"ldap_group_search_scope,omitempty"`
-	EmailSsl                        bool   `json:"email_ssl"`
-	EmailPort                       int    `json:"email_port,omitempty"`
-	EmailHost                       string `json:"email_host,omitempty"`
-	EmailFrom                       string `json:"email_from,omitempty"`
-	RobotTokenDuration              int    `json:"robot_token_duration,omitempty"`
-	LdapVerifyCert                  bool   `json:"ldap_verify_cert,omitempty"`
-	LdapGroupGID                    string `json:"ldap_group_gid,omitempty"`
-	OidcAdminGroup                  string `json:"oidc_admin_group,omitempty"`
-	RobotNamePrefix                 string `json:"robot_name_prefix,omitempty"`
+	LdapTimeout                  int    `json:"ldap_timeout,omitempty"`
+	LdapBaseDn                   string `json:"ldap_base_dn,omitempty"`
+	LdapFilter                   string `json:"ldap_filter,omitempty"`
+	LdapURL                      string `json:"ldap_url,omitempty"`
+	OidcName                     string `json:"oidc_name,omitempty"`
+	LdapUID                      string `json:"ldap_uid,omitempty"`
+	OidcClientID                 string `json:"oidc_client_id,omitempty"`
+	LdapGroupBaseDn              string `json:"ldap_group_base_dn,omitempty"`
+	LdapGroupAttributeName       string `json:"ldap_group_attribute_name,omitempty"`
+	LdapGroupMembershipAttribute string `json:"ldap_group_membership_attribute,omitempty"`
+	LdapSearchPassword           string `json:"ldap_search_password,omitempty"`
+	LdapGroupAdminDn             string `json:"ldap_group_admin_dn,omitempty"`
+	OidcEndpoint                 string `json:"oidc_endpoint,omitempty"`
+	OidcClientSecret             string `json:"oidc_client_secret,omitempty"`
+	OidcGroupsClaim              string `json:"oidc_groups_claim,omitempty"`
+	LdapScope                    int    `json:"ldap_scope,omitempty"`
+	TokenExpiration              int    `json:"token_expiration,omitempty"`
+	LdapGroupSearchScope         int    `json:"ldap_group_search_scope,omitempty"`
+	LdapVerifyCert               bool   `json:"ldap_verify_cert,omitempty"`
+	LdapGroupGID                 string `json:"ldap_group_gid,omitempty"`
+	OidcAdminGroup               string `json:"oidc_admin_group,omitempty"`
+}
+
+type ConfigBodySystemPost struct {
+	ProjectCreationRestriction string `json:"project_creation_restriction,omitempty"`
+	ReadOnly                   bool   `json:"read_only"`
+	RobotTokenDuration         int    `json:"robot_token_duration,omitempty"`
+	QuotaPerProjectEnable      bool   `json:"quota_per_project_enable"`
+	RobotNamePrefix            string `json:"robot_name_prefix,omitempty"`
+	StoragePerProject          string `json:"storage_per_project,omitempty"`
+}
+
+type ConfigBodyEmailPost struct {
+	EmailHost     string `json:"email_host,omitempty"`
+	EmailPort     int    `json:"email_port,omitempty"`
+	EmailUsername string `json:"email_username,omitempty"`
+	EmailPassword string `json:"email_password,omitempty"`
+	EmailFrom     string `json:"email_from,omitempty"`
+	EmailSsl      bool   `json:"email_ssl"`
+	EmailInsecure bool   `json:"email_insecure"`
+	EmailIdentity string `json:"email_identity,omitempty"`
 }
 
 type ConfigBodyResponse struct {
@@ -182,10 +187,6 @@ type ConfigBodyResponse struct {
 		Editable bool `json:"editable,omitempty"`
 		Value    int  `json:"value,omitempty"`
 	} `json:"ldap_scope,omitempty"`
-	CountPerProject struct {
-		Editable bool `json:"editable,omitempty"`
-		Value    int  `json:"value,omitempty"`
-	} `json:"count_per_project,omitempty"`
 	TokenExpiration struct {
 		Editable bool `json:"editable,omitempty"`
 		Value    int  `json:"value,omitempty"`


### PR DESCRIPTION
Harbor API /configuration is split into three separate resources within this provider:
- harbor_config_auth
- harbor_config_system
- harbor_config_email

The same [ConfigBodyPost](https://github.com/goharbor/terraform-provider-harbor/blob/a112dbf114d8a94fbedf1b0a13482f90ebd33de5/models/config.go#L5) structure is used for all three resources. This should be fine, but current implementation doesn't handle empty bool properly when no input is given, resulting in silently  evaluating certain attributes to false / conflicting behavior between mentioned Tf resources. 

For example:
First apply harbor_config_auth with oidc_verify_cert and oidc_auto_onboard set to true --> applied correctly 
Secondly, apply harbor_config_system --.> This will reset oidc_verify_cert and oidc_auto_onboard to false in the 'background'. 
See this issue for example https://github.com/goharbor/terraform-provider-harbor/issues/227

This applies to more attributes, for example QuotaPerProjectEnable. I noticed this was 'fixed' partially in the past with this PR: https://github.com/goharbor/terraform-provider-harbor/pull/74 However, this only fixes it for the harbor_config_system, if you apply harbor_config_auth or harbor_config_email aftewards, QuotaPerProjectEnable is 'silently' reverted to false, depending on the deployment order.

To mitigate this issue, I moved the attributes for each Tf resource to it's own BodyPost structure. In the future you probably want to handle empty values in a better way and maybe move the three resources into one, to keep it in line with the Harbor API.