### PR TITLE
Add namespace flattening options to replication body. 

### DIFF
--- a/client/replication.go
+++ b/client/replication.go
@@ -14,12 +14,13 @@ func GetReplicationBody(d *schema.ResourceData) models.ReplicationBody {
 	schedule := d.Get("schedule").(string)
 
 	body := models.ReplicationBody{
-		Name:          d.Get("name").(string),
-		Description:   d.Get("description").(string),
-		Override:      d.Get("override").(bool),
-		Enabled:       d.Get("enabled").(bool),
-		Deletion:      d.Get("deletion").(bool),
-		DestNamespace: d.Get("dest_namespace").(string),
+		Name:                 d.Get("name").(string),
+		Description:          d.Get("description").(string),
+		Override:             d.Get("override").(bool),
+		Enabled:              d.Get("enabled").(bool),
+		Deletion:             d.Get("deletion").(bool),
+		DestNamespace:        d.Get("dest_namespace").(string),
+		DestNamespaceReplace: d.Get("dest_namespace_replace").(int),
 	}
 
 	if action == "push" {

--- a/docs/resources/replication.md
+++ b/docs/resources/replication.md
@@ -60,11 +60,12 @@ The following arguments are supported:
 
 * **action** - (Required)
 
-* **schedule** - (Optional) The scheduled time of when the container register will be push / pull. In cron base format. Hourly `"0 0 * * * *"`, Daily `"0 0 0 * * *"`, Monthly `"0 0 0 * * 0"`. Can be one of the follow. `event_based`, `manual`, `cron format` (Default: `manual`)
+* **schedule** - (Optional) The scheduled time of when the container register will be push / pull. In cron base format. Hourly `"0 0 * * * *"`, Daily `"0 0 0 * * *"`, Monthly `"0 0 0 * * 0"`. Can be one of the following: `event_based`, `manual`, `cron format` (Default: `manual`)
 * **override** - (Optional) Specify whether to override the resources at the destination if a resources with the same name exist. Can be set to `true` or `false` (Default: `true`)
 * **enabled** - (Optional) Specify whether the replication is enabled. Can be set to `true` or `false` (Default: `true`)
-* **description** - (Optional) Write about description of the replication policy.
+* **description** - (Optional) Description of the replication policy.
 * **dest_namespace** - (Optional) Specify the destination namespace. if empty, the resource will be put under the same namespace as the source.
+* **dest_namespace_replace** - (Optional) Specify the destination namespace flattening policy. Integers from `-1` to `3` are valid values in the harbor API. A value of `-1` will 'Flatten All Levels', `0` means 'No Flattening', `1` 'Flatten 1 Level', `2` 'Flatten 2 Levels', `3` 'Flatten 3 Levels' (Default: `0`, see [Replication Rules](https://goharbor.io/docs/latest/administration/configuring-replication/create-replication-rules/) for more details)
 * **deletion** - (Optional) Specify whether to delete the remote resources when locally deleted. Can be set to `true` or `false` (Default: `false`)
 
 * **filters** - (Optional) A collection of `filters` block as documented below.

--- a/models/replications.go
+++ b/models/replications.go
@@ -12,8 +12,9 @@ type ReplicationBody struct {
 	DestRegistry struct {
 		ID int `json:"id,omitempty"`
 	} `json:"dest_registry,omitempty"`
-	DestNamespace string `json:"dest_namespace,omitempty"`
-	Trigger       struct {
+	DestNamespace        string `json:"dest_namespace,omitempty"`
+	DestNamespaceReplace int    `json:"dest_namespace_replace_count"`
+	Trigger              struct {
 		Type            string `json:"type,omitempty"`
 		TriggerSettings struct {
 			Cron string `json:"cron,omitempty"`
@@ -26,7 +27,7 @@ type ReplicationBody struct {
 }
 
 type ReplicationFilters struct {
-	Type  string      `json:"type,omitempty"`
-	Value interface{} `json:"value,omitempty"`
+	Type       string      `json:"type,omitempty"`
+	Value      interface{} `json:"value,omitempty"`
 	Decoration string      `json:"decoration,omitempty"`
 }

--- a/provider/resource_replication.go
+++ b/provider/resource_replication.go
@@ -52,6 +52,11 @@ func resourceReplication() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"dest_namespace_replace": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
 			"override": {
 				Type:     schema.TypeBool,
 				Optional: true,

--- a/provider/resource_replication_test.go
+++ b/provider/resource_replication_test.go
@@ -54,7 +54,7 @@ func testAccCheckReplicationDestroy(s *terraform.State) error {
 
 		resp, _, _, err := apiClient.SendRequest("GET", rs.Primary.ID, nil, 404)
 		if err != nil {
-			return fmt.Errorf("Resouse was not delete \n %s", resp)
+			return fmt.Errorf("Resource was not deleted \n %s", resp)
 		}
 
 	}
@@ -124,6 +124,29 @@ func TestDestinationNamespace(t *testing.T) {
 	})
 }
 
+func TestDestinationNamespaceReplaceCount(t *testing.T) {
+	var scheduleType = "* 0/15 * * * *"
+	var destNamespaceReplaceCount = 0
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		// CheckDestroy: testAccCheckLabelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testReplicationPolicyDestinationNamespaceWithReplaceCount(scheduleType, destNamespaceReplaceCount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceExists(harborReplicationPull),
+					resource.TestCheckResourceAttr(
+						harborReplicationPull, "schedule", scheduleType),
+					resource.TestCheckResourceAttr(
+						harborReplicationPull, "dest_namespace_replace", fmt.Sprintf("%d", destNamespaceReplaceCount)),
+				),
+			},
+		},
+	})
+}
+
 func testReplicationPolicyDestinationNamespace(scheduleType string, destNamepace string) string {
 	// endpoint := os.Getenv("HARBOR_REPLICATION_ENDPOINT")
 	endpoint := "https://hub.docker.com"
@@ -140,6 +163,27 @@ func testReplicationPolicyDestinationNamespace(scheduleType string, destNamepace
 		registry_id = harbor_registry.main.registry_id
 		schedule = "%s"
 		dest_namespace = "%s"
+	  }
+	`, endpoint, scheduleType, destNamepace)
+}
+
+func testReplicationPolicyDestinationNamespaceWithReplaceCount(scheduleType string, destNamepace int) string {
+	// endpoint := os.Getenv("HARBOR_REPLICATION_ENDPOINT")
+	endpoint := "https://hub.docker.com"
+	return fmt.Sprintf(`
+	resource "harbor_registry" "main" {
+		provider_name = "docker-hub"
+		name = "docker-hub-test-rep-pol"
+		endpoint_url = "%s"
+	  }
+
+	  resource "harbor_replication" "pull" {
+		name  = "test_pull"
+		action = "pull"
+		registry_id = harbor_registry.main.registry_id
+		schedule = "%s"
+		dest_namespace = "nobody_cares"
+		dest_namespace_replace = "%d"
 	  }
 	`, endpoint, scheduleType, destNamepace)
 }


### PR DESCRIPTION
Adds flattening support to the replication policy.

This fixes #167. 

Verified working against v2.3.3+vmware.1-a0a9ed8a