### PR TITLE
Add support for reading harbor_interrogation_services

### DIFF
--- a/models/interogations.go
+++ b/models/interogations.go
@@ -1,0 +1,7 @@
+package models
+
+type InterogationsBodyResponse struct {
+	Schedule struct {
+		Type string `json:"type,omitempty"`
+	}
+}

--- a/provider/resource_interrogation_services.go
+++ b/provider/resource_interrogation_services.go
@@ -45,6 +45,7 @@ func resourceVulnCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceVulnRead(d *schema.ResourceData, m interface{}) error {
+	d.SetId("/system/scanAll/schedule")
 	apiClient := m.(*client.Client)
 	resp, _, respCode, err := apiClient.SendRequest("GET", d.Id(), nil, 200)
 


### PR DESCRIPTION
This PR should fix the issue in https://github.com/goharbor/terraform-provider-harbor/issues/245 by adding a proper way of reading the endpoint.

I haven't tested this on a real deployment of Harbor due to lack of time and no access to any cluster at the moment.

EDIT: I have now tested this on Harbor v2.6.2-498e7e21 deployed in AKS with terraform version v1.3.3 and everything now works as expected.