### PR TITLE
Add support for setting the replication bandwidth limits

### DIFF
--- a/client/replication.go
+++ b/client/replication.go
@@ -21,6 +21,7 @@ func GetReplicationBody(d *schema.ResourceData) models.ReplicationBody {
 		Deletion:             d.Get("deletion").(bool),
 		DestNamespace:        d.Get("dest_namespace").(string),
 		DestNamespaceReplace: d.Get("dest_namespace_replace").(int),
+		Speed:                d.Get("speed").(int),
 	}
 
 	if action == "push" {

--- a/docs/resources/replication.md
+++ b/docs/resources/replication.md
@@ -60,6 +60,10 @@ The following arguments are supported:
 
 * **action** - (Required)
 
+* **registry_id** - (Required) The registry ID of the Registry Endpoint
+
+* **speed** - (Optional) The Maximum network bandwidth in Kbps for each execution. Default is `0` (unlimited).
+
 * **schedule** - (Optional) The scheduled time of when the container register will be push / pull. In cron base format. Hourly `"0 0 * * * *"`, Daily `"0 0 0 * * *"`, Monthly `"0 0 0 * * 0"`. Can be one of the following: `event_based`, `manual`, `cron format` (Default: `manual`)
 * **override** - (Optional) Specify whether to override the resources at the destination if a resources with the same name exist. Can be set to `true` or `false` (Default: `true`)
 * **enabled** - (Optional) Specify whether the replication is enabled. Can be set to `true` or `false` (Default: `true`)

--- a/models/replications.go
+++ b/models/replications.go
@@ -24,6 +24,7 @@ type ReplicationBody struct {
 	Deletion bool                 `json:"deletion,omitempty"`
 	Override bool                 `json:"override,omitempty"`
 	Filters  []ReplicationFilters `json:"filters,omitempty"`
+	Speed    int                  `json:"speed,omitempty"`
 }
 
 type ReplicationFilters struct {

--- a/provider/resource_replication.go
+++ b/provider/resource_replication.go
@@ -93,6 +93,11 @@ func resourceReplication() *schema.Resource {
 					},
 				},
 			},
+			"speed": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
 		},
 		Create: resourceReplicationCreate,
 		Read:   resourceReplicationRead,


### PR DESCRIPTION
As raised in https://github.com/goharbor/terraform-provider-harbor/issues/250 a need to set the bandwidth limit during replication was needed. This PR implements that setting.

This PR also updates the docs according.

This PR also updates the docs with information about `registry_id` which is a required parameter.