### PR TITLE
fix invalid new value for .dest_namespace_replace was cty.NumberIntVal(0), but now null

### DIFF
--- a/models/replications.go
+++ b/models/replications.go
@@ -13,7 +13,7 @@ type ReplicationBody struct {
 		ID int `json:"id,omitempty"`
 	} `json:"dest_registry,omitempty"`
 	DestNamespace        string `json:"dest_namespace,omitempty"`
-	DestNamespaceReplace int    `json:"dest_namespace_replace_count"`
+	DestNamespaceReplace int    `json:"dest_namespace_replace_count,omitempty"`
 	Trigger              struct {
 		Type            string `json:"type,omitempty"`
 		TriggerSettings struct {


### PR DESCRIPTION
fix invalid new value for .dest_namespace_replace was cty.NumberIntVal(0), but now null

the bug seems to happen when moving from the previous "BESTSELLER/harbor" provider to "goharbor/harbor" provider with no dest_namespace_replace 