### PR TITLE
Wrong default value in documentation

### DIFF
--- a/docs/resources/registry.md
+++ b/docs/resources/registry.md
@@ -27,7 +27,7 @@ The following arguments are supported:
 
 * **access_secret** - (Optional) The password / access keys / token for the external container register
 
-* **insecure** - (Optional) Verifies the certificate of the external container register. Can be set to **"true"** or **"false"** (Default: true)
+* **insecure** - (Optional) Verifies the certificate of the external container register. Can be set to **"true"** or **"false"** (Default: false)
 
 * **enabled** - (Optional) enables / disables the external container register within harbor. Can be set to **"true"** or **"false"** (Default: true)
 


### PR DESCRIPTION
The default value for insecure in a registry resource is false not true.

Signed-off-by: letic <anthony.callegaro@protonmail.com>