### PR TITLE
remove whitespaces in tag lists

### DIFF
--- a/client/replication.go
+++ b/client/replication.go
@@ -56,7 +56,7 @@ func GetReplicationBody(d *schema.ResourceData) models.ReplicationBody {
 		}
 		if tag != "" {
 			filter.Type = "tag"
-			filter.Value = tag
+			filter.Value = strings.ReplaceAll(tag, " ", "")
 			filter.Decoration = decoration
 		}
 		if len(label) > 0 {


### PR DESCRIPTION
For some reason when multiple tags are supplied in a tag list for an image and there's a white space between different tags Harbor only grabs the first tag so by removing whitespaces before sending the list to harbor it fix the issue.

```terraform
# Will ignore 3.8.0-alpine
 filters {
    tag = "{3.8.0-linux, 3.8.0-alpine}"
  }
```

But this 
```terraform
# Works fine
 filters {
    tag = "{3.8.0-linux,3.8.0-alpine}"
  }
```

Signed-off-by: Ahmed Khaled <ahmed.khaled1512@yahoo.com>