### PR TITLE
add docs on which environment variables are used for provider config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,15 @@ provider "harbor" {
   password = "insert_password_here"
 }
 ```
+
+Alternatively, these environment variables can be used to set the provider config values:
+```
+HARBOR_URL
+HARBOR_USERNAME
+HARBOR_PASSWORD
+HARBOR_IGNORE_CERT
+```
+
 ## Argument Reference
 The following arguments are supported:
 


### PR DESCRIPTION
Implements suggested change from issue #305 