### PR TITLE
fix webhook tests

### DIFF
--- a/docs/resources/project_webhook.md
+++ b/docs/resources/project_webhook.md
@@ -12,9 +12,6 @@ resource "harbor_project_webhook" "main" {
     "DELETE_ARTIFACT",
     "PULL_ARTIFACT",
     "PUSH_ARTIFACT",
-    "DELETE_CHART",
-    "DOWNLOAD_CHART",
-    "UPLOAD_CHART",
     "QUOTA_EXCEED",
     "QUOTA_WARNING",
     "REPLICATION",
@@ -39,6 +36,6 @@ The following arguments are supported:
 * `enabled` - (Optional, bool), To enable / disable the webhook. Default `true` 
 * `project_id` - (Required, string) The project id of the harbor that webhook related to.
 * `notify_type` - (Required, string) The notification type either `http` or `slack`
-* `events_types` - (Required, list(string)) The type events you want to subscript to can be `DELETE_ARTIFACT`, `PULL_ARTIFACT`, `PUSH_ARTIFACT`, `DELETE_CHART`, `DOWNLOAD_CHART`, `UPLOAD_CHART`, `QUOTA_EXCEED`, `QUOTA_WARNING`, `REPLICATION`, `SCANNING_FAILED`, `SCANNING_COMPLETED`, `TAG_RETENTION`
+* `events_types` - (Required, list(string)) The type events you want to subscript to can be `DELETE_ARTIFACT`, `PULL_ARTIFACT`, `PUSH_ARTIFACT`, `QUOTA_EXCEED`, `QUOTA_WARNING`, `REPLICATION`, `SCANNING_FAILED`, `SCANNING_COMPLETED`, `TAG_RETENTION`
 * `auth_header` - (Required, string) authentication header for you the webhook
 * `skip_cert_verify` - (Optional - bool) checks the for validate SSL certificate.

--- a/provider/resource_harbor_project_webhook_test.go
+++ b/provider/resource_harbor_project_webhook_test.go
@@ -30,7 +30,7 @@ func TestAccProjectWebhook(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						harborProjectWebhook, "name", "acctest_webhook"),
 					resource.TestCheckResourceAttr(
-						harborProjectWebhook, "events_types.#", "12"),
+						harborProjectWebhook, "events_types.#", "9"),
 				),
 			},
 			{
@@ -81,9 +81,6 @@ func testAccCheckProjectWebhook(projectName string) string {
 		  "DELETE_ARTIFACT",
 		  "PULL_ARTIFACT",
 		  "PUSH_ARTIFACT",
-		  "DELETE_CHART",
-		  "DOWNLOAD_CHART",
-		  "UPLOAD_CHART",
 		  "QUOTA_EXCEED",
 		  "QUOTA_WARNING",
 		  "REPLICATION",


### PR DESCRIPTION
Since Harbor 2.8.0 was released, chart museum is gone, so these tests were failing.