### PR TITLE
Harbor config system project quota

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -12,7 +12,7 @@ func GetConfigSystem(d *schema.ResourceData) models.ConfigBodySystemPost {
 	var body models.ConfigBodySystemPost
 	storage := d.Get("storage_per_project").(int)
 	if storage > 0 {
-		storage *= 1073741824 // GB
+		storage *= 1073741824 // GB to Byte
 	}
 	body = models.ConfigBodySystemPost{
 		ProjectCreationRestriction: d.Get("project_creation_restriction").(string),

--- a/client/config.go
+++ b/client/config.go
@@ -10,6 +10,10 @@ import (
 
 func GetConfigSystem(d *schema.ResourceData) models.ConfigBodySystemPost {
 	var body models.ConfigBodySystemPost
+	storage := d.Get("storage_per_project").(int)
+	if storage > 0 {
+		storage *= 1073741824 // GB
+	}
 	body = models.ConfigBodySystemPost{
 		ProjectCreationRestriction: d.Get("project_creation_restriction").(string),
 		ReadOnly:                   d.Get("read_only").(bool),
@@ -17,6 +21,7 @@ func GetConfigSystem(d *schema.ResourceData) models.ConfigBodySystemPost {
 		RobotTokenDuration:         d.Get("robot_token_expiration").(int),
 		QuotaPerProjectEnable:      true,
 		RobotNamePrefix:            d.Get("robot_name_prefix").(string),
+		StoragePerProject:          storage,
 	}
 	log.Printf("[DEBUG] %+v\n ", body)
 	return body

--- a/docs/resources/config_system.md
+++ b/docs/resources/config_system.md
@@ -7,6 +7,7 @@ resource "harbor_config_system" "main" {
   project_creation_restriction = "adminonly"
   robot_token_expiration       = 30
   robot_name_prefix            = "harbor@"
+  storage_per_project          = 100
 }
 ```
 
@@ -15,10 +16,12 @@ The following arguments are supported:
 
 * **project_creation_restriction** - (Optional) Who can create projects within Harbor. Can be **"adminonly"** or **"everyone"**
 
-* **robot_token_expiration** - (Optional) The amount of time in days a robot account will expiry. 
+* **robot_token_expiration** - (Optional) The amount of time in days a robot account will expiry.
 
 * **robot_name_prefix** - (Optional) Robot account prefix.
 `NOTE: If the time is set to high you will get a 500 internal server error message when creating robot accounts`
 
 * **scanner_skip_update_pulltime** - (Optional) Whether or not to skip update pull time for scanner.
 `NOTE: "scanner_skip_update_pulltime" can only be used with harbor version v2.8.0 and above`
+
+* **storage_per_project** - (Optional) Default quota space per project in GIB. Default is -1 (unlimited).

--- a/docs/resources/config_system.md
+++ b/docs/resources/config_system.md
@@ -16,7 +16,7 @@ The following arguments are supported:
 
 * **project_creation_restriction** - (Optional) Who can create projects within Harbor. Can be **"adminonly"** or **"everyone"**
 
-* **robot_token_expiration** - (Optional) The amount of time in days a robot account will expiry.
+* **robot_token_expiration** - (Optional) The amount of time in days a robot account will expiry. 
 
 * **robot_name_prefix** - (Optional) Robot account prefix.
 `NOTE: If the time is set to high you will get a 500 internal server error message when creating robot accounts`

--- a/models/config.go
+++ b/models/config.go
@@ -48,7 +48,7 @@ type ConfigBodySystemPost struct {
 	RobotTokenDuration         int    `json:"robot_token_duration,omitempty"`
 	QuotaPerProjectEnable      bool   `json:"quota_per_project_enable"`
 	RobotNamePrefix            string `json:"robot_name_prefix,omitempty"`
-	StoragePerProject          string `json:"storage_per_project,omitempty"`
+	StoragePerProject          int    `json:"storage_per_project,omitempty"`
 	ScannerSkipUpdatePulltime  bool   `json:"scanner_skip_update_pulltime"`
 }
 

--- a/provider/resource_config_system.go
+++ b/provider/resource_config_system.go
@@ -37,6 +37,11 @@ func resourceConfigSystem() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"storage_per_project": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  -1,
+			},
 		},
 		Create: resourceConfigSystemCreate,
 		Read:   resourceConfigSystemRead,

--- a/provider/resource_config_system.go
+++ b/provider/resource_config_system.go
@@ -83,12 +83,17 @@ func resourceConfigSystemRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error getting system configuration %s", err)
 	}
+	storage := jsonData.StoragePerProject.Value
+	if storage > 0 {
+		storage /= 1073741824 // Byte to GB
+	}
 
 	d.Set("project_creation_restriction", jsonData.ProjectCreationRestriction.Value)
 	d.Set("read_only", jsonData.ReadOnly.Value)
 	d.Set("robot_token_expiration", jsonData.RobotTokenDuration.Value)
 	d.Set("robot_name_prefix", jsonData.RobotNamePrefix.Value)
 	d.Set("scanner_skip_update_pulltime", jsonData.ScannerSkipUpdatePulltime.Value)
+	d.Set("storage_per_project", storage)
 
 	d.SetId("configuration/system")
 	return nil


### PR DESCRIPTION
This PR implement the option to set default storage quotas for the projects.

This fixes https://github.com/goharbor/terraform-provider-harbor/issues/359 