### PR TITLE
Add enable_content_trust_cosign option (matching api)

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -38,6 +38,7 @@ func ProjectBody(d *schema.ResourceData) models.ProjectsBodyPost {
 	}
 
 	body.Metadata.EnableContentTrust = strconv.FormatBool(d.Get("enable_content_trust").(bool))
+	body.Metadata.EnableContentTrustCosign = strconv.FormatBool(d.Get("enable_content_trust_cosign").(bool))
 
 	cveAllowList := d.Get("cve_allowlist").([]interface{})
 	log.Printf("[DEBUG] %v ", cveAllowList)

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -3,10 +3,11 @@
 ## Example Usage
 ```hcl
 resource "harbor_project" "main" {
-    name                    = "main"
-    public                  = false               # (Optional) Default value is false
-    vulnerability_scanning  = true                # (Optional) Default vale is true. Automatically scan images on push
-    enable_content_trust    = true                # (Optional) Default vale is false. Deny unsigned images from being pulled
+    name                        = "main"
+    public                      = false               # (Optional) Default value is false
+    vulnerability_scanning      = true                # (Optional) Default value is true. Automatically scan images on push
+    enable_content_trust        = true                # (Optional) Default value is false. Deny unsigned images from being pulled (notary)
+    enable_content_trust_cosign = false               # (Optional) Default value is false. Deny unsigned images from being pulled (cosign)
 }
 ```
 
@@ -41,6 +42,8 @@ The following arguments are supported:
 * `storage_quota` - (Optional) The storage quota of the project in GB's
 
 * `enable_content_trust` - (Optional) Enables Content Trust for project. When enabled it queries the embedded docker notary server. Can be set to `"true"` or `"false"` (Default: false)
+
+* `enable_content_trust_cosign` - (Optional) Enables Content Trust Cosign for project. When enabled it queries Cosign. Can be set to `"true"` or `"false"` (Default: false)
 
 * `force_destroy` - (Optional, Default: `false`) A boolean that indicates all repositories should be deleted from the project so that the project can be destroyed without error. These repositories are *not* recoverable.
 

--- a/models/projects.go
+++ b/models/projects.go
@@ -17,12 +17,13 @@ type ProjectsBodyPost struct {
 	} `json:"cve_allowlist,omitempty"`
 	StorageLimit int `json:"storage_limit,omitempty"`
 	Metadata     struct {
-		EnableContentTrust   string `json:"enable_content_trust,omitempty"`
-		AutoScan             string `json:"auto_scan,omitempty"`
-		Severity             string `json:"severity,omitempty"`
-		ReuseSysCveAllowlist string `json:"reuse_sys_cve_allowlist,omitempty"`
-		Public               string `json:"public,omitempty"`
-		PreventVul           string `json:"prevent_vul,omitempty"`
+		EnableContentTrust       string `json:"enable_content_trust,omitempty"`
+		EnableContentTrustCosign string `json:"enable_content_trust_cosign,omitempty"`
+		AutoScan                 string `json:"auto_scan,omitempty"`
+		Severity                 string `json:"severity,omitempty"`
+		ReuseSysCveAllowlist     string `json:"reuse_sys_cve_allowlist,omitempty"`
+		Public                   string `json:"public,omitempty"`
+		PreventVul               string `json:"prevent_vul,omitempty"`
 	} `json:"metadata,omitempty"`
 }
 
@@ -49,13 +50,14 @@ type ProjectsBodyResponses struct {
 		ExpiresAt int `json:"expires_at"`
 	} `json:"cve_allowlist"`
 	Metadata struct {
-		EnableContentTrust   string `json:"enable_content_trust,omitempty"`
-		AutoScan             string `json:"auto_scan,omitempty"`
-		Severity             string `json:"severity"`
-		ReuseSysCveAllowlist string `json:"reuse_sys_cve_allowlist"`
-		Public               string `json:"public"`
-		PreventVul           string `json:"prevent_vul"`
-		RetentionId          string `json:"retention_id"`
+		EnableContentTrust       string `json:"enable_content_trust,omitempty"`
+		EnableContentTrustCosign string `json:"enable_content_trust_cosign,omitempty"`
+		AutoScan                 string `json:"auto_scan,omitempty"`
+		Severity                 string `json:"severity"`
+		ReuseSysCveAllowlist     string `json:"reuse_sys_cve_allowlist"`
+		Public                   string `json:"public"`
+		PreventVul               string `json:"prevent_vul"`
+		RetentionId              string `json:"retention_id"`
 	} `json:"metadata"`
 }
 

--- a/provider/resource_project.go
+++ b/provider/resource_project.go
@@ -59,6 +59,11 @@ func resourceProject() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"enable_content_trust_cosign": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"force_destroy": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -126,12 +131,24 @@ func resourceProjectRead(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
+	var trustCosign bool
+	trustContentCosign := jsonData.Metadata.EnableContentTrustCosign
+	if trustContentCosign == "" {
+		trustCosign = false
+	} else {
+		trustCosign, err = strconv.ParseBool(trustContentCosign)
+		if err != nil {
+			return err
+		}
+	}
+
 	d.Set("name", jsonData.Name)
 	d.Set("project_id", jsonData.ProjectID)
 	d.Set("registry_id", jsonData.RegistryID)
 	d.Set("public", jsonData.Metadata.Public)
 	d.Set("vulnerability_scanning", vuln)
 	d.Set("enable_content_trust", trust)
+	d.Set("enable_content_trust_cosign", trustCosign)
 
 	return nil
 }

--- a/provider/resource_project_test.go
+++ b/provider/resource_project_test.go
@@ -11,6 +11,7 @@ import (
 
 const resourceHarborProjectMain = "harbor_project.main"
 const enableContentTrust = "enable_content_trust"
+const enableContentTrustCosign = "enable_content_trust_cosign"
 
 func testAccCheckProjectDestroy(s *terraform.State) error {
 	apiClient := testAccProvider.Meta().(*client.Client)


### PR DESCRIPTION
We use terraform harbor provider to deploy our harbor resources. The option enable_content_trust_cosign was missing. (which is present in de harbor api)

Pull Request is to get this option into the terraform provider