### PR TITLE
Fix retention_policy.schedule empty state

### DIFF
--- a/provider/resource_retention_policy.go
+++ b/provider/resource_retention_policy.go
@@ -215,10 +215,12 @@ func resolveScope(model models.Retention) interface{} {
 
 func resolveSchedule(model models.Retention) string {
 	fmt, _ := client.GetSchedule(model.Trigger.Settings.Cron)
-	if fmt == "Custom" {
+	switch fmt {
+	case "Custom", "None":
 		return model.Trigger.Settings.Cron
+	default:
+		return fmt
 	}
-	return fmt
 }
 
 func resolveRules(model models.Retention) []interface{} {

--- a/provider/resource_retention_policy_test.go
+++ b/provider/resource_retention_policy_test.go
@@ -31,6 +31,22 @@ func TestAccRetentionUpdate(t *testing.T) {
 						resourceHarborRetentionMain, "rule.0.tag_matching", "latest"),
 				),
 			},
+			{
+				Config: testAccCheckRetentionScheduleNone(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceExists(resourceHarborRetentionMain),
+					resource.TestCheckResourceAttr(
+						resourceHarborRetentionMain, "schedule", ""),
+					resource.TestCheckResourceAttr(
+						resourceHarborRetentionMain, "rule.0.n_days_since_last_pull", "5"),
+					resource.TestCheckResourceAttr(
+						resourceHarborRetentionMain, "rule.0.disabled", "false"),
+					resource.TestCheckResourceAttr(
+						resourceHarborRetentionMain, "rule.0.repo_matching", "**"),
+					resource.TestCheckResourceAttr(
+						resourceHarborRetentionMain, "rule.0.tag_matching", "latest"),
+				),
+			},
 			// {
 			// 	Config: testAccCheckLabelUpdate(),
 			// 	Check: resource.ComposeTestCheckFunc(
@@ -70,7 +86,7 @@ func testAccCheckRetentionBasic() string {
 	resource "harbor_project" "main" {
 		name                = "acctest_retention_pol"
 	  }
-	  
+
 	  resource "harbor_retention_policy" "main" {
 		  scope = harbor_project.main.id
 		  schedule = "Daily"
@@ -84,7 +100,31 @@ func testAccCheckRetentionBasic() string {
 			  repo_matching = "**"
 			  tag_matching = "latest"
 		  }
-	  
+
+	  }
+	`)
+}
+
+func testAccCheckRetentionScheduleNone() string {
+	return fmt.Sprintf(`
+	resource "harbor_project" "main" {
+			name                = "acctest_retention_pol"
+	  }
+
+	  resource "harbor_retention_policy" "main" {
+		  scope = harbor_project.main.id
+		  schedule = ""
+		  rule {
+			  n_days_since_last_pull = 5
+			  repo_matching = "**"
+			  tag_matching = "latest"
+		  }
+		  rule {
+			  n_days_since_last_push = 10
+			  repo_matching = "**"
+			  tag_matching = "latest"
+		  }
+
 	  }
 	`)
 }


### PR DESCRIPTION
 - Save empty string to the state when no schedule is given

Having a `harbor_retention_policy` resource with an empty schedule (which matches `None` schedule in Harbor UI), provider tries to update it on every `terraform apply` execution:

```
# harbor_retention_policy.retention_policy[0] will be updated in-place
~ resource "harbor_retention_policy" "retention_policy" {
      id       = "/retentions/1"
    - schedule = "None" -> ""
}
```

This happens because the state is saved as `"None"` and desired state is actually an empty string.

```
"schedule": "None",
```

With the fix applied terraform stops updating the state on every run:

```
harbor_retention_policy.retention_policy[0]: Refreshing state... [id=/retentions/1]
No changes. Your infrastructure matches the configuration.
```

and saves the schedule as an empty string:

```
"schedule": "",
```