### PR TITLE
Harbor requires 6 cron values

### DIFF
--- a/docs/resources/garbage_collection.md
+++ b/docs/resources/garbage_collection.md
@@ -24,7 +24,7 @@ resource "harbor_garbage_collection" "main" {
 
 ### Required
 
-- `schedule` (String) Sets the schedule how often the Garbage Collection will run.  Can be to `"hourly"`, `"daily"`, `"weekly"` or can be a custom cron string ie, `"5 4 * * *"` 
+- `schedule` (String) Sets the schedule how often the Garbage Collection will run.  Can be to `"hourly"`, `"daily"`, `"weekly"` or can be a custom cron string ie, `"0 5 4 * * *"` 
 
 ### Optional
 

--- a/templates/resources/garbage_collection.md.tmpl
+++ b/templates/resources/garbage_collection.md.tmpl
@@ -22,7 +22,7 @@ For example, the {{ .SchemaMarkdown }} template can be used to replace manual sc
 
 ### Required
 
-- `schedule` (String) Sets the schedule how often the Garbage Collection will run.  Can be to `"hourly"`, `"daily"`, `"weekly"` or can be a custom cron string ie, `"5 4 * * *"` 
+- `schedule` (String) Sets the schedule how often the Garbage Collection will run.  Can be to `"hourly"`, `"daily"`, `"weekly"` or can be a custom cron string ie, `"0 5 4 * * *"` 
 
 ### Optional
 


### PR DESCRIPTION
Harbor requires the custom time to be in a 6 field cron format.