### PR TITLE
fix: readd crucial documentation about curly brackets for tags or repositories

### DIFF
--- a/docs/resources/retention_policy.md
+++ b/docs/resources/retention_policy.md
@@ -52,6 +52,8 @@ resource "harbor_retention_policy" "main" {
 
 ### Nested Schema for `rule`
 
+~> Multiple tags or repositories must be provided as a comma-separated list wrapped into curly brackets `{ }`. Otherwise, the value is interpreted as a single value.
+
 Optional:
 
 - `always_retain` (Boolean) retain always.

--- a/templates/resources/retention_policy.md.tmpl
+++ b/templates/resources/retention_policy.md.tmpl
@@ -37,6 +37,8 @@ For example, the {{ .SchemaMarkdown }} template can be used to replace manual sc
 
 ### Nested Schema for `rule`
 
+~> Multiple tags or repositories must be provided as a comma-separated list wrapped into curly brackets `{ }`. Otherwise, the value is interpreted as a single value.
+
 Optional:
 
 - `always_retain` (Boolean) retain always.


### PR DESCRIPTION
Hi,
while using the provider I had problems with adding policies to multiple repos.

The behaviour was initially documented with https://github.com/goharbor/terraform-provider-harbor/pull/324 but seems to have been lost with https://github.com/goharbor/terraform-provider-harbor/pull/412.