### PR TITLE
Terraform forces replacement if the project-level robot account prefix contains plus sign (fixes #479)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/goharbor/terraform-provider-harbor
 
-go 1.22
-toolchain go1.22.5
+go 1.22.0
+
+toolchain go1.23.4
 
 require github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
 

--- a/provider/resource_robot_account.go
+++ b/provider/resource_robot_account.go
@@ -159,7 +159,7 @@ func resourceRobotAccountRead(d *schema.ResourceData, m interface{}) error {
 
 	var shortName string
 	if robot.Level == "project" {
-		shortName = strings.Split(robot.Name, "+")[1]
+		shortName = strings.Split(robot.Name, robot.Permissions[0].Namespace+"+")[1]
 	} else {
 		resp, _, respCode, err := apiClient.SendRequest("GET", models.PathConfig, nil, 200)
 		if respCode == 404 && err != nil {


### PR DESCRIPTION
fixes #479