### PR TITLE
Correct error message when destroying projects without force

### DIFF
--- a/provider/resource_project.go
+++ b/provider/resource_project.go
@@ -230,7 +230,7 @@ func resourceProjectDelete(d *schema.ResourceData, m interface{}) error {
 		projectName := d.Get("name").(string)
 		repos, _ := apiClient.GetProjectRepositories(projectName)
 		if len(repos) != 0 {
-			return fmt.Errorf("project %s is not empty, please set force_delete to TRUE to clean all repositories", projectName)
+			return fmt.Errorf("project %s is not empty, please set force_destroy to TRUE to clean all repositories", projectName)
 		}
 	}
 


### PR DESCRIPTION
The error message shown when trying to destroy a non-empty project asked to set `force_delete` to true, but no such variable is available. The PR corrects the message to say `force_destroy` instead.