### PR TITLE
Escape registry name in URL query string for harbor_registry data source

### DIFF
--- a/provider/data_registry.go
+++ b/provider/data_registry.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 
 	"github.com/goharbor/terraform-provider-harbor/client"
@@ -49,7 +50,7 @@ func dataRegistry() *schema.Resource {
 func dataRegistryRead(d *schema.ResourceData, m interface{}) error {
 	apiClient := m.(*client.Client)
 	name := d.Get("name").(string)
-	registryPath := models.PathRegistries + "?name=" + name
+	registryPath := models.PathRegistries + "?name=" + url.QueryEscape(name)
 	resp, _, _, err := apiClient.SendRequest("GET", registryPath, nil, 200)
 	if err != nil {
 		return err

--- a/provider/data_registry_test.go
+++ b/provider/data_registry_test.go
@@ -1,0 +1,43 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceRegistry_basic(t *testing.T) {
+	for _, rName := range []string{"Foo", "Foo bar"} {
+		t.Run(rName, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { testAccPreCheck(t) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccDataSourceRegistryConfig_basicDataSource(rName),
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr("data.harbor_registry.test", "name", rName),
+							resource.TestCheckResourceAttr("data.harbor_registry.test", "type", "docker-hub"),
+							resource.TestCheckResourceAttr("data.harbor_registry.test", "url", "https://hub.docker.com"),
+						),
+					},
+				},
+			})
+		})
+	}
+}
+
+func testAccDataSourceRegistryConfig_basicDataSource(rName string) string {
+	return fmt.Sprintf(`
+resource "harbor_registry" "test" {
+	provider_name = "docker-hub"
+    name = "%s"
+	endpoint_url = "https://hub.docker.com"
+}
+
+data "harbor_registry" "test" {
+    name = harbor_registry.test.name
+}
+`, rName)
+}


### PR DESCRIPTION
Added test cases for registry names with and withouth spaces. Not sure if I did it right way.

Closes #511