### PR TITLE
Update maximum workers in resource_garbage_collection.go

### DIFF
--- a/docs/resources/garbage_collection.md
+++ b/docs/resources/garbage_collection.md
@@ -29,7 +29,7 @@ resource "harbor_garbage_collection" "main" {
 ### Optional
 
 - `delete_untagged` (Boolean) Allow garbage collection on untagged artifacts.
-- `workers` (Number) Number of workers to run the garbage collection, value must be between 1 and 5.
+- `workers` (Number) Number of workers to run the garbage collection, value must be greater than or equal to one. Harbor limits the number of concurrent workers internally, setting this value higher than what Harbor supports will result in an error.
 
 ### Read-Only
 

--- a/provider/resource_garbage_collection.go
+++ b/provider/resource_garbage_collection.go
@@ -25,8 +25,7 @@ func resourceGC() *schema.Resource {
 				Optional: true,
 				Default:  1,
 				ValidateFunc: func(i interface{}, k string) (ws []string, errors []error) {
-					value := i.(int)
-					if value < 1 || value > 10 {
+					if i.(int) < 1 {
 						errors = append(errors, fmt.Errorf("GC workers must be between 1 and 10"))
 					}
 					return

--- a/provider/resource_garbage_collection.go
+++ b/provider/resource_garbage_collection.go
@@ -26,8 +26,8 @@ func resourceGC() *schema.Resource {
 				Default:  1,
 				ValidateFunc: func(i interface{}, k string) (ws []string, errors []error) {
 					value := i.(int)
-					if value < 1 || value > 5 {
-						errors = append(errors, fmt.Errorf("GC workers must be between 1 and 5"))
+					if value < 1 || value > 10 {
+						errors = append(errors, fmt.Errorf("GC workers must be between 1 and 10"))
 					}
 					return
 				},

--- a/templates/resources/garbage_collection.md.tmpl
+++ b/templates/resources/garbage_collection.md.tmpl
@@ -27,7 +27,7 @@ For example, the {{ .SchemaMarkdown }} template can be used to replace manual sc
 ### Optional
 
 - `delete_untagged` (Boolean) Allow garbage collection on untagged artifacts.
-- `workers` (Number) Number of workers to run the garbage collection, value must be between 1 and 5.
+- `workers` (Number) Number of workers to run the garbage collection, value must be greater than or equal to one. Harbor limits the number of concurrent workers internally, setting this value higher than what Harbor supports will result in an error.
 
 ### Read-Only
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,8 +1,7 @@
 module github.com/hashicorp/terraform-provider-awscc/tools
 
-go 1.23.0
-
-toolchain go1.24.3
+go 1.22
+toolchain go1.24.1
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,7 +1,8 @@
 module github.com/hashicorp/terraform-provider-awscc/tools
 
-go 1.22
-toolchain go1.24.1
+go 1.23.0
+
+toolchain go1.24.3
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
Harbor v2.13.0 introduced the ability to have up to 10 garbage collection workers. This change should allow that value to be configured in the provider. See https://github.com/goharbor/harbor/releases/tag/v2.13.0, more specifically introduced in https://github.com/goharbor/harbor/pull/21462