### PR TITLE
Add payload_format prop to project_webhook

### DIFF
--- a/client/project_webhook.go
+++ b/client/project_webhook.go
@@ -19,6 +19,7 @@ func ProjectWebhookBody(d *schema.ResourceData) models.ProjectWebhook {
 		AuthHeader:     d.Get("auth_header").(string),
 		SkipCertVerify: d.Get("skip_cert_verify").(bool),
 		Address:        d.Get("address").(string),
+		PayloadFormat:  d.Get("payload_format").(string),
 	}
 
 	body.Targets = append(body.Targets, targets)

--- a/docs/resources/project_webhook.md
+++ b/docs/resources/project_webhook.md
@@ -66,6 +66,7 @@ resource "harbor_project_webhook" "main" {
 - `description` (String) A description of the webhook.
 - `enabled` (Boolean) To enable / disable the webhook. Default `true`.
 - `skip_cert_verify` (Boolean) checks the for validate SSL certificate.
+- `payload_format` (String) Payload format sent by the webhook. Values are `Default` or `CloudEvents`. Default to `Default`.
 
 ### Read-Only
 

--- a/models/project_webhooks.go
+++ b/models/project_webhooks.go
@@ -19,4 +19,5 @@ type WebHookTargets struct {
 	AuthHeader     string `json:"auth_header"`
 	SkipCertVerify bool   `json:"skip_cert_verify"`
 	Address        string `json:"address"`
+	PayloadFormat  string `json:"payload_format"`
 }

--- a/provider/resource_harbor_project_webhook.go
+++ b/provider/resource_harbor_project_webhook.go
@@ -56,6 +56,11 @@ func resourceProjectWebhook() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"payload_format": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Default",
+			},
 		},
 		Create: resourceProjectWebhookCreate,
 		Read:   resourceProjectWebhookRead,
@@ -106,6 +111,7 @@ func resourceProjectWebhookRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("address", jsonData.Targets[0].Address)
 	d.Set("auth_header", jsonData.Targets[0].AuthHeader)
 	d.Set("skip_cert_verify", jsonData.Targets[0].SkipCertVerify)
+	d.Set("payload_format", jsonData.Targets[0].PayloadFormat)
 
 	return nil
 }


### PR DESCRIPTION
The property `payload_format` was missing on the resource `harbor_project_webhook `. 

This PR add it to the `WebHookTargets` model, along other optional properties about the webhook's target.

It was tested locally and works fine.