### PR TITLE
check twice for forbidden before return (fixes #554)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -117,6 +117,9 @@ func (c *Client) SendRequest(method string, path string, payload interface{}, st
 				}
 			}
 		}
+	}
+
+	if resp.StatusCode == http.StatusForbidden {
 		return "", "", resp.StatusCode, fmt.Errorf("[ERROR] forbidden: status=%s, code=%d \nIf you are using a robot account, this is likely due to RBAC limitations. See: https://github.com/goharbor/community/blob/main/proposals/new/Robot-Account-Expand.md", resp.Status, resp.StatusCode)
 	}
 


### PR DESCRIPTION
https://github.com/goharbor/terraform-provider-harbor/commit/5248a3a2d4ac9ec990fced4b04f9fb4ede45cd8b introduced better error handling for FORBIDDEN errors.
This caused a slight regression in the authentication handling for OIDC logins (introduced in #497).

This PR moves the error message outside of the "retry" block.