### PR TITLE
fix(project_member_group): resolve LDAP DN to usergroup id (fixes #591)

### DIFF
--- a/client/group.go
+++ b/client/group.go
@@ -1,15 +1,183 @@
 package client
 
 import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/goharbor/terraform-provider-harbor/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// GroupBody return a json body
+// Harbor user group types, as returned/accepted by the /usergroups API.
+const (
+	GroupTypeLDAP     = 1
+	GroupTypeInternal = 2
+	GroupTypeOIDC     = 3
+)
+
+// GroupBody returns a JSON body built from resource data.
 func GroupBody(d *schema.ResourceData) models.GroupBody {
 	return models.GroupBody{
 		Groupname:   d.Get("group_name").(string),
 		GroupType:   d.Get("group_type").(int),
 		LdapGroupDn: d.Get("ldap_group_dn").(string),
 	}
+}
+
+// GroupTypeName returns the string form of a Harbor group type, inverse of
+// GroupType. Unknown values return an empty string.
+func GroupTypeName(t int) string {
+	switch t {
+	case GroupTypeLDAP:
+		return "ldap"
+	case GroupTypeInternal:
+		return "internal"
+	case GroupTypeOIDC:
+		return "oidc"
+	}
+	return ""
+}
+
+// ListGroups fetches all Harbor user groups, paginating through the API.
+// Harbor returns an empty page once the list is exhausted.
+func (c *Client) ListGroups() ([]models.GroupBody, error) {
+	var groups []models.GroupBody
+	for page := 1; ; page++ {
+		resp, _, _, err := c.SendRequest("GET", models.PathGroups+"?page="+strconv.Itoa(page), nil, 200)
+		if err != nil {
+			return nil, fmt.Errorf("list usergroups page %d: %w", page, err)
+		}
+
+		var pageData []models.GroupBody
+		if err := json.Unmarshal([]byte(resp), &pageData); err != nil {
+			return nil, fmt.Errorf("decode usergroups page %d: %w", page, err)
+		}
+		if len(pageData) == 0 {
+			break
+		}
+		groups = append(groups, pageData...)
+	}
+	return groups, nil
+}
+
+// GetGroupByID returns a single usergroup by its numeric id.
+func (c *Client) GetGroupByID(id int) (*models.GroupBody, error) {
+	resp, _, code, err := c.SendRequest("GET", fmt.Sprintf("%s/%d", models.PathGroups, id), nil, 200)
+	if err != nil {
+		return nil, fmt.Errorf("get usergroup %d (status %d): %w", id, code, err)
+	}
+	var g models.GroupBody
+	if err := json.Unmarshal([]byte(resp), &g); err != nil {
+		return nil, fmt.Errorf("decode usergroup %d: %w", id, err)
+	}
+	// The /usergroups/{id} endpoint does not echo the id in the body, so
+	// propagate the one we already know.
+	g.ID = id
+	return &g, nil
+}
+
+// CreateGroup creates a new usergroup and returns its numeric id, parsed from
+// the Location response header.
+func (c *Client) CreateGroup(g models.GroupBody) (int, error) {
+	_, headers, _, err := c.SendRequest("POST", models.PathGroups, g, 201)
+	if err != nil {
+		return 0, fmt.Errorf("create usergroup %q: %w", g.Groupname, err)
+	}
+	loc, err := GetID(headers)
+	if err != nil {
+		return 0, fmt.Errorf("parse Location of created usergroup: %w", err)
+	}
+	// loc looks like "/usergroups/25".
+	idx := strings.LastIndex(loc, "/")
+	if idx < 0 || idx == len(loc)-1 {
+		return 0, fmt.Errorf("unexpected usergroup Location %q", loc)
+	}
+	id, err := strconv.Atoi(loc[idx+1:])
+	if err != nil {
+		return 0, fmt.Errorf("parse usergroup id from Location %q: %w", loc, err)
+	}
+	return id, nil
+}
+
+// ResolveOrCreateLdapGroup looks up an LDAP-backed usergroup by its distinguished
+// name, creating it if absent. It returns the resolved numeric id and whether
+// an existing group was adopted (false means the group was just created).
+//
+// Harbor's POST /projects/{pid}/members endpoint has a known failure mode when
+// called with member_group.ldap_group_dn: it creates the backing usergroup as
+// a side effect but then returns HTTP 500 on the member attachment, leaving an
+// orphan. Resolving the DN here and passing a numeric member_group.id to the
+// members endpoint avoids that path entirely and also adopts any orphan left
+// over from a prior failure.
+func (c *Client) ResolveOrCreateLdapGroup(dn, name string) (id int, adopted bool, err error) {
+	if dn == "" {
+		return 0, false, fmt.Errorf("ldap group DN must not be empty")
+	}
+	if existing, err := c.lookupLdapGroupByDN(dn); err != nil {
+		return 0, false, err
+	} else if existing != 0 {
+		return existing, true, nil
+	}
+	if name == "" {
+		name = ShortNameFromDN(dn)
+	}
+	id, createErr := c.CreateGroup(models.GroupBody{
+		Groupname:   name,
+		GroupType:   GroupTypeLDAP,
+		LdapGroupDn: dn,
+	})
+	if createErr == nil {
+		return id, false, nil
+	}
+	// If another concurrent apply created the same group between our List
+	// and our Create, Harbor rejects the second POST with an "already exist"
+	// error. Re-list and try to adopt before surfacing the error.
+	if existing, lookupErr := c.lookupLdapGroupByDN(dn); lookupErr == nil && existing != 0 {
+		return existing, true, nil
+	}
+	return 0, false, createErr
+}
+
+// lookupLdapGroupByDN returns the id of the LDAP-backed usergroup matching dn,
+// or 0 if no match is found. Comparison is case-insensitive.
+func (c *Client) lookupLdapGroupByDN(dn string) (int, error) {
+	groups, err := c.ListGroups()
+	if err != nil {
+		return 0, err
+	}
+	for _, g := range groups {
+		if g.GroupType == GroupTypeLDAP && strings.EqualFold(g.LdapGroupDn, dn) {
+			return g.ID, nil
+		}
+	}
+	return 0, nil
+}
+
+// ShortNameFromDN extracts the value of the first RDN in a distinguished name,
+// e.g. "cn=harbor_users,cn=groups,dc=example" -> "harbor_users". If the input
+// is not a DN, it is returned unchanged.
+func ShortNameFromDN(dn string) string {
+	first := strings.SplitN(dn, ",", 2)[0]
+	if eq := strings.Index(first, "="); eq >= 0 {
+		return strings.TrimSpace(first[eq+1:])
+	}
+	return dn
+}
+
+// LooksLikeDN reports whether s looks like an LDAP distinguished name. This is
+// a loose heuristic used only for back-compat: older configurations allowed a
+// DN in `group_name`, and we want to keep accepting that transparently.
+func LooksLikeDN(s string) bool {
+	if !strings.Contains(s, "=") {
+		return false
+	}
+	head := strings.ToLower(strings.SplitN(s, "=", 2)[0])
+	head = strings.TrimSpace(head)
+	switch head {
+	case "cn", "ou", "dc", "uid", "o":
+		return true
+	}
+	return false
 }

--- a/client/group_test.go
+++ b/client/group_test.go
@@ -1,0 +1,215 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/goharbor/terraform-provider-harbor/models"
+)
+
+func TestGroupTypeRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		num  int
+	}{
+		{"ldap", GroupTypeLDAP},
+		{"internal", GroupTypeInternal},
+		{"oidc", GroupTypeOIDC},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := GroupType(c.name); got != c.num {
+				t.Errorf("GroupType(%q) = %d, want %d", c.name, got, c.num)
+			}
+			if got := GroupTypeName(c.num); got != c.name {
+				t.Errorf("GroupTypeName(%d) = %q, want %q", c.num, got, c.name)
+			}
+		})
+	}
+	if GroupTypeName(0) != "" || GroupTypeName(99) != "" {
+		t.Errorf("GroupTypeName should return empty for unknown types")
+	}
+}
+
+func TestLooksLikeDN(t *testing.T) {
+	cases := map[string]bool{
+		"cn=harbor_users,cn=groups,dc=example,dc=com": true,
+		"CN=Admins,OU=Groups,DC=Example,DC=com":       true,
+		"uid=alice,ou=people,dc=example,dc=com":       true,
+		"harbor_users":                                false,
+		"":                                            false,
+		"name=value":                                  false, // unknown RDN head
+	}
+	for in, want := range cases {
+		if got := LooksLikeDN(in); got != want {
+			t.Errorf("LooksLikeDN(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestShortNameFromDN(t *testing.T) {
+	cases := map[string]string{
+		"cn=harbor_users,cn=groups,dc=example,dc=com": "harbor_users",
+		"CN=Admins ,OU=x": "Admins",
+		"plain":           "plain",
+	}
+	for in, want := range cases {
+		if got := ShortNameFromDN(in); got != want {
+			t.Errorf("ShortNameFromDN(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestProjectMembersGroupBodyByID(t *testing.T) {
+	body := ProjectMembersGroupBodyByID("developer", 42)
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(raw)
+	// Critical: the DN-bearing fields must never leak into the members POST
+	// body; that is the exact shape that triggers the Harbor 500 bug.
+	for _, forbidden := range []string{"ldap_group_dn", "group_name", "group_type"} {
+		if strings.Contains(s, forbidden) {
+			t.Errorf("member body must not contain %q, got %s", forbidden, s)
+		}
+	}
+	if !strings.Contains(s, `"id":42`) {
+		t.Errorf("member body missing resolved group id, got %s", s)
+	}
+	if body.RoleID != 2 {
+		t.Errorf("RoleID = %d, want 2 (developer)", body.RoleID)
+	}
+}
+
+// fakeHarbor is a minimal stand-in for Harbor's /usergroups endpoints used by
+// the resolver tests. It supports pagination, lookup and create.
+type fakeHarbor struct {
+	groups   []models.GroupBody
+	nextID   int32
+	creates  int32
+	lastPost models.GroupBody
+}
+
+func (f *fakeHarbor) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/usergroups", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			// Single page of results; return empty for any page != 1.
+			page := r.URL.Query().Get("page")
+			if page != "" && page != "1" {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("[]"))
+				return
+			}
+			_ = json.NewEncoder(w).Encode(f.groups)
+		case http.MethodPost:
+			var g models.GroupBody
+			if err := json.NewDecoder(r.Body).Decode(&g); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			id := int(atomic.AddInt32(&f.nextID, 1))
+			g.ID = id
+			f.groups = append(f.groups, g)
+			f.lastPost = g
+			atomic.AddInt32(&f.creates, 1)
+			w.Header().Set("Location", fmt.Sprintf("/api/v2.0/usergroups/%d", id))
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+	return mux
+}
+
+func newTestClient(t *testing.T, f *fakeHarbor) (*Client, func()) {
+	t.Helper()
+	srv := httptest.NewServer(f.handler())
+	c := NewClient(srv.URL, "user", "pass", "", "", false, "")
+	return c, srv.Close
+}
+
+func TestResolveOrCreateLdapGroup_Adopts(t *testing.T) {
+	f := &fakeHarbor{
+		nextID: 10,
+		groups: []models.GroupBody{
+			{ID: 7, Groupname: "harbor_users", GroupType: GroupTypeLDAP, LdapGroupDn: "cn=harbor_users,dc=example,dc=com"},
+		},
+	}
+	c, stop := newTestClient(t, f)
+	defer stop()
+
+	id, adopted, err := c.ResolveOrCreateLdapGroup("CN=harbor_users,DC=example,DC=com", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !adopted {
+		t.Errorf("expected to adopt existing group")
+	}
+	if id != 7 {
+		t.Errorf("id = %d, want 7", id)
+	}
+	if f.creates != 0 {
+		t.Errorf("should not have created a group, creates=%d", f.creates)
+	}
+}
+
+func TestResolveOrCreateLdapGroup_Creates(t *testing.T) {
+	f := &fakeHarbor{nextID: 100}
+	c, stop := newTestClient(t, f)
+	defer stop()
+
+	id, adopted, err := c.ResolveOrCreateLdapGroup("cn=new_group,dc=example,dc=com", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adopted {
+		t.Errorf("expected to create, not adopt")
+	}
+	if id != 101 {
+		t.Errorf("id = %d, want 101", id)
+	}
+	if f.lastPost.Groupname != "new_group" {
+		t.Errorf("derived name = %q, want new_group", f.lastPost.Groupname)
+	}
+	if f.lastPost.GroupType != GroupTypeLDAP {
+		t.Errorf("group_type = %d, want %d", f.lastPost.GroupType, GroupTypeLDAP)
+	}
+}
+
+func TestResolveOrCreateLdapGroup_EmptyDN(t *testing.T) {
+	f := &fakeHarbor{}
+	c, stop := newTestClient(t, f)
+	defer stop()
+	if _, _, err := c.ResolveOrCreateLdapGroup("", ""); err == nil {
+		t.Errorf("expected error for empty DN")
+	}
+}
+
+func TestGetGroupByID(t *testing.T) {
+	want := models.GroupBody{Groupname: "harbor_users", GroupType: GroupTypeLDAP, LdapGroupDn: "cn=harbor_users,dc=example,dc=com"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/usergroups/25" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(want)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "u", "p", "", "", false, "")
+	got, err := c.GetGroupByID(25)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != 25 || got.Groupname != want.Groupname || got.LdapGroupDn != want.LdapGroupDn {
+		t.Errorf("got %+v, want id=25 name=%s dn=%s", got, want.Groupname, want.LdapGroupDn)
+	}
+}

--- a/client/project_members.go
+++ b/client/project_members.go
@@ -5,20 +5,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func ProjectMembersGroupBody(d *schema.ResourceData) models.ProjectMembersBodyPost {
-	body := models.ProjectMembersBodyPost{
-		RoleID: RoleType(d.Get("role").(string)),
+// ProjectMembersGroupBodyByID builds a project member POST/PUT body that
+// attaches an already-existing Harbor usergroup by its numeric id.
+//
+// This is the only shape the Harbor members API handles reliably: passing
+// ldap_group_dn here triggers a server-side 500 on Harbor versions that create
+// the backing usergroup as a side effect. Callers must resolve the DN to an id
+// first (see Client.ResolveOrCreateLdapGroup).
+func ProjectMembersGroupBodyByID(role string, groupID int) models.ProjectMembersBodyPost {
+	return models.ProjectMembersBodyPost{
+		RoleID: RoleType(role),
 		GroupMember: models.ProjectMembersBodyGroup{
-			GroupType: GroupType(d.Get("type").(string)),
-			GroupName: d.Get("group_name").(string),
-			GroupID:   d.Get("group_id").(int),
+			GroupID: groupID,
 		},
 	}
-
-	if v, ok := d.GetOk("ldap_group_dn"); ok {
-		body.GroupMember.LdapGroupDN = v.(string)
-	}
-	return body
 }
 
 func ProjectMembersUserBody(d *schema.ResourceData) models.ProjectMembersBodyPost {

--- a/docs/resources/project_member_group.md
+++ b/docs/resources/project_member_group.md
@@ -3,7 +3,7 @@
 page_title: "harbor_project_member_group Resource - terraform-provider-harbor"
 subcategory: ""
 description: |-
-  
+
 ---
 
 # harbor_project_member_group (Resource)
@@ -12,18 +12,43 @@ description: |-
 
 ## Example Usage
 
+### OIDC / internal group
+
 ```terraform
 resource "harbor_project" "main" {
     name = "main"
 }
 
 resource "harbor_project_member_group" "main" {
-  project_id    = harbor_project.main.id
-  group_name    = "testing1"
-  role          = "projectadmin"
-  type          = "oidc"
+  project_id = harbor_project.main.id
+  group_name = "testing1"
+  role       = "projectadmin"
+  type       = "oidc"
 }
 ```
+
+### LDAP group
+
+For LDAP-backed members the recommended input is the group's distinguished
+name via `ldap_group_dn`. The provider will resolve the DN to an existing
+Harbor usergroup, or create one on the fly, and then attach the project
+member by numeric id. This avoids a known Harbor server-side failure mode in
+which passing `ldap_group_dn` directly to `POST /projects/{id}/members`
+creates the backing usergroup as a side effect but returns HTTP 500.
+
+```terraform
+resource "harbor_project_member_group" "ldap_users" {
+  project_id    = harbor_project.main.id
+  role          = "developer"
+  type          = "ldap"
+  ldap_group_dn = "cn=harbor_users,cn=groups,dc=example,dc=com"
+}
+```
+
+Older configurations that put the DN directly into `group_name` without an
+`ldap_group_dn` field keep working: the provider detects a DN shape and
+transparently routes it through the same resolver. A deprecation warning is
+emitted in the log; new configurations should use `ldap_group_dn`.
 
 ## Schema
 
@@ -31,28 +56,39 @@ resource "harbor_project_member_group" "main" {
 
 - `project_id` (String) The project id of the project that the entity will have access to.
 - `role` (String) The permissions that the entity will be granted.
-- `type` (String) The group type.  Can be set to `"ldap"`, `"internal"` or `"oidc"`.
+- `type` (String) The group type. Can be set to `"ldap"`, `"internal"` or `"oidc"`. Changing this forces a new resource.
 
 #### Notes
 `type` can only be `oidc` when used with harbor version v1.10.1 and above.
 
 ### Optional
 
-- `group_id` (Number) The numeric identifier of the group type. Valid values are `1`, `2`, or `3` :
-  - `1` = `ldap`
-  - `2` = `internal`
-  - `3` = `oidc`
-- `group_name` (String) The name of the group member entity.
-- `ldap_group_dn` (String) The distinguished name of the group within AD/LDAP.
+- `group_id` (Number) Numeric id of an existing Harbor usergroup. When set, the
+  provider skips the name/DN lookup entirely and attaches the member by id.
+- `group_name` (String) Name of the group member. For `internal` and `oidc`
+  types this is the identifying name. For `ldap` it is populated from the
+  backing usergroup after create/read and tracks whatever short name Harbor
+  returns; a distinguished name supplied here is accepted for back-compat.
+- `ldap_group_dn` (String) Distinguished name of the LDAP group. Preferred
+  input for `type = "ldap"`. The provider resolves the DN against
+  `/usergroups`, adopts an existing entry when present, and creates one when
+  absent. The backing usergroup is never deleted on resource destroy, since it
+  may be shared across projects.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `member_id` (Number)
+- `member_id` (Number) Numeric id of the project member.
 
 ## Import
-Import is supported using the following syntax with the `project` and `member` `id`'s:
+
+Import is supported using the following syntax with the `project` and `member`
+`id`'s:
 
 ```shell
 terraform import harbor_project_member_group.main /projects/10/members/200
 ```
+
+After import, the first `plan` is expected to be clean: `type`, `group_name`
+and `ldap_group_dn` are all derived from the backing usergroup, so no
+cosmetic drift is surfaced against a well-formed configuration.

--- a/models/project_members.go
+++ b/models/project_members.go
@@ -8,11 +8,12 @@ type ProjectMembersBodyPost struct {
 }
 
 type ProjectMembersBodyResponses struct {
-	ID          int                     `json:"id,omitempty"`
-	RoleID      int                     `json:"role_id,omitempty"`
-	ProjectID   int                     `json:"project_id,omitempty"`
-	EntityType  string                  `json:"entity_type,omitempty"`
-	EntityName  string                  `json:"entity_name,omitempty"`
+	ID         int    `json:"id,omitempty"`
+	RoleID     int    `json:"role_id,omitempty"`
+	ProjectID  int    `json:"project_id,omitempty"`
+	EntityID   int    `json:"entity_id,omitempty"`
+	EntityType string `json:"entity_type,omitempty"`
+	EntityName string `json:"entity_name,omitempty"`
 }
 
 type ProjectMembersBodyGroup struct {
@@ -25,5 +26,3 @@ type ProjectMembersBodyGroup struct {
 type ProjectMemberUsersGroup struct {
 	UserName string `json:"username,omitempty"`
 }
-
-

--- a/provider/resource_project_member_group.go
+++ b/provider/resource_project_member_group.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"strconv"
 
 	"github.com/goharbor/terraform-provider-harbor/client"
@@ -21,17 +22,26 @@ func resourceMembersGroup() *schema.Resource {
 			"group_name": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
+				Computed: true,
+				// Back-compat: older configurations put an LDAP DN directly
+				// into group_name. The current Read populates group_name with
+				// the short form returned by the /usergroups endpoint, which
+				// would otherwise produce a permanent diff against those old
+				// configs. Suppress the diff when old and new both point at
+				// the same backing LDAP usergroup.
+				DiffSuppressFunc: suppressLdapGroupNameDiff,
 			},
 			"group_id": {
 				Type:         schema.TypeInt,
 				Optional:     true,
+				Computed:     true,
 				ForceNew:     true,
-				AtLeastOneOf: []string{"group_id", "group_name"},
+				AtLeastOneOf: []string{"group_id", "group_name", "ldap_group_dn"},
 			},
 			"ldap_group_dn": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"member_id": {
 				Type:     schema.TypeInt,
@@ -55,6 +65,7 @@ func resourceMembersGroup() *schema.Resource {
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(string)
 					if v != "ldap" && v != "internal" && v != "oidc" {
@@ -74,16 +85,110 @@ func resourceMembersGroup() *schema.Resource {
 	}
 }
 
+// ldapGroupNameEquivalent reports whether two group_name values refer to the
+// same backing LDAP usergroup — i.e. one is the distinguished name and the
+// other is its first-RDN short form, or they are identical. It is pure logic
+// so it can be unit-tested without constructing a schema.ResourceData.
+func ldapGroupNameEquivalent(groupType, ldapDN, old, new string) bool {
+	if groupType != "ldap" || ldapDN == "" {
+		return false
+	}
+	short := client.ShortNameFromDN(ldapDN)
+	matches := func(v string) bool { return v == ldapDN || v == short }
+	return matches(old) && matches(new)
+}
+
+// suppressLdapGroupNameDiff is the schema-level wrapper around
+// ldapGroupNameEquivalent. It keeps existing state backwards-compatible for
+// users who historically put the DN directly into group_name before
+// ldap_group_dn existed or was enforced.
+func suppressLdapGroupNameDiff(_, old, new string, d *schema.ResourceData) bool {
+	return ldapGroupNameEquivalent(
+		d.Get("type").(string),
+		d.Get("ldap_group_dn").(string),
+		old, new,
+	)
+}
+
+// resolveMemberGroupID resolves the configured group_id / group_name /
+// ldap_group_dn inputs to a concrete Harbor usergroup id, creating the
+// usergroup on the fly for LDAP-backed groups when it does not exist yet.
+//
+// For type=ldap we never pass ldap_group_dn through to the members endpoint —
+// that path triggers a server-side 500 on known Harbor versions. See
+// Client.ResolveOrCreateLdapGroup for details.
+func resolveMemberGroupID(apiClient *client.Client, d *schema.ResourceData) (int, error) {
+	if id, ok := d.GetOk("group_id"); ok {
+		return id.(int), nil
+	}
+	groupType := d.Get("type").(string)
+	groupName := d.Get("group_name").(string)
+	ldapDN := d.Get("ldap_group_dn").(string)
+	if groupType == "ldap" {
+		return resolveLdapMemberGroupID(apiClient, ldapDN, groupName)
+	}
+	return resolveNamedMemberGroupID(apiClient, groupType, groupName)
+}
+
+// resolveLdapMemberGroupID handles type=ldap by resolving or creating the
+// backing usergroup and returning its numeric id. A DN supplied in group_name
+// is accepted for back-compat with older configurations.
+func resolveLdapMemberGroupID(apiClient *client.Client, ldapDN, groupName string) (int, error) {
+	if ldapDN == "" && client.LooksLikeDN(groupName) {
+		log.Printf("[WARN] harbor_project_member_group: treating group_name %q as ldap_group_dn for back-compat; please move the DN to the ldap_group_dn field", groupName)
+		ldapDN = groupName
+		groupName = ""
+	}
+	if ldapDN == "" {
+		return 0, fmt.Errorf("type=ldap requires either group_id or ldap_group_dn")
+	}
+	id, adopted, err := apiClient.ResolveOrCreateLdapGroup(ldapDN, groupName)
+	if err != nil {
+		return 0, err
+	}
+	action := "created"
+	if adopted {
+		action = "adopted existing"
+	}
+	log.Printf("[DEBUG] harbor_project_member_group: %s ldap usergroup id=%d dn=%q", action, id, ldapDN)
+	return id, nil
+}
+
+// resolveNamedMemberGroupID handles type=internal and type=oidc by looking up
+// an existing Harbor usergroup by name. It does not create usergroups; callers
+// must manage them with harbor_group.
+func resolveNamedMemberGroupID(apiClient *client.Client, groupType, groupName string) (int, error) {
+	if groupName == "" {
+		return 0, fmt.Errorf("type=%s requires either group_id or group_name", groupType)
+	}
+	groups, err := apiClient.ListGroups()
+	if err != nil {
+		return 0, err
+	}
+	wantType := client.GroupType(groupType)
+	for _, g := range groups {
+		if g.GroupType == wantType && g.Groupname == groupName {
+			return g.ID, nil
+		}
+	}
+	return 0, fmt.Errorf("usergroup %q of type %q not found; create it first with harbor_group", groupName, groupType)
+}
+
 func resourceMembersGroupCreate(d *schema.ResourceData, m interface{}) error {
 	apiClient := m.(*client.Client)
 	projectid := checkProjectid(d.Get("project_id").(string))
 	path := projectid + "/members"
 
-	body := client.ProjectMembersGroupBody(d)
+	groupID, err := resolveMemberGroupID(apiClient, d)
+	if err != nil {
+		return err
+	}
+
+	body := client.ProjectMembersGroupBodyByID(d.Get("role").(string), groupID)
 
 	_, headers, _, err := apiClient.SendRequest("POST", path, body, 201)
 	if err != nil {
-		return err
+		return fmt.Errorf("create project member (group_id=%d): %w", groupID, err)
 	}
 
 	id, err := client.GetID(headers)
@@ -106,24 +211,49 @@ func resourceMembersGroupRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	var jsonData models.ProjectMembersBodyResponses
-	err = json.Unmarshal([]byte(resp), &jsonData)
-	if err != nil {
-		return fmt.Errorf("resource not found %s", d.Id())
+	var member models.ProjectMembersBodyResponses
+	if err := json.Unmarshal([]byte(resp), &member); err != nil {
+		return fmt.Errorf("decode project member %s: %w", d.Id(), err)
 	}
-	d.Set("role", client.RoleTypeNumber(jsonData.RoleID))
-	d.Set("project_id", checkProjectid(strconv.Itoa(jsonData.ProjectID)))
-	d.Set("group_name", jsonData.EntityName)
+
+	d.Set("role", client.RoleTypeNumber(member.RoleID))
+	d.Set("project_id", checkProjectid(strconv.Itoa(member.ProjectID)))
+	d.Set("member_id", member.ID)
+
+	// For group members, use the backing usergroup as the source of truth so
+	// that `type`, `group_name` and `ldap_group_dn` stay stable across refresh
+	// and import and don't drift back to the short form Harbor returns on the
+	// members endpoint.
+	if member.EntityType == "g" && member.EntityID > 0 {
+		g, err := apiClient.GetGroupByID(member.EntityID)
+		if err != nil {
+			return err
+		}
+		d.Set("group_id", g.ID)
+		d.Set("group_name", g.Groupname)
+		d.Set("ldap_group_dn", g.LdapGroupDn)
+		if typeName := client.GroupTypeName(g.GroupType); typeName != "" {
+			d.Set("type", typeName)
+		}
+		return nil
+	}
+
+	// Fallback for older Harbor responses that omit entity_id: keep the
+	// previous best-effort behaviour.
+	d.Set("group_name", member.EntityName)
 	return nil
 }
 
 func resourceMembersGroupUpdate(d *schema.ResourceData, m interface{}) error {
 	apiClient := m.(*client.Client)
 
-	body := client.ProjectMembersGroupBody(d)
-	_, _, _, err := apiClient.SendRequest("PUT", d.Id(), body, 200)
-	if err != nil {
-		fmt.Println(err)
+	// Only the role is mutable on an existing member; everything else is
+	// either ForceNew or derived from the backing usergroup.
+	body := models.ProjectMembersBodyPost{
+		RoleID: client.RoleType(d.Get("role").(string)),
+	}
+	if _, _, _, err := apiClient.SendRequest("PUT", d.Id(), body, 200); err != nil {
+		return fmt.Errorf("update project member %s: %w", d.Id(), err)
 	}
 
 	return resourceMembersGroupRead(d, m)

--- a/provider/resource_project_member_group_unit_test.go
+++ b/provider/resource_project_member_group_unit_test.go
@@ -1,0 +1,43 @@
+package provider
+
+import "testing"
+
+func TestLdapGroupNameEquivalent(t *testing.T) {
+	const dn = "cn=harbor_users,cn=groups,dc=example,dc=com"
+	const short = "harbor_users"
+
+	cases := []struct {
+		name      string
+		groupType string
+		ldapDN    string
+		old, new  string
+		want      bool
+	}{
+		// The main back-compat case: state holds short name (written by the
+		// new Read), config still has the DN from before the fix.
+		{"ldap DN <-> short both directions (old=short)", "ldap", dn, short, dn, true},
+		{"ldap DN <-> short both directions (old=DN)", "ldap", dn, dn, short, true},
+		{"ldap identical DN on both sides", "ldap", dn, dn, dn, true},
+		{"ldap identical short on both sides", "ldap", dn, short, short, true},
+
+		// Real diffs must not be suppressed.
+		{"ldap unrelated name", "ldap", dn, short, "someone_else", false},
+		{"ldap DN vs unrelated", "ldap", dn, dn, "cn=other,dc=example,dc=com", false},
+
+		// Non-ldap types must never be suppressed, even with matching values.
+		{"internal never suppressed", "internal", "", short, short, false},
+		{"oidc never suppressed even with DN", "oidc", dn, dn, short, false},
+
+		// ldap without a DN in state: nothing to compare against.
+		{"ldap without DN not suppressed", "ldap", "", short, short, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ldapGroupNameEquivalent(tc.groupType, tc.ldapDN, tc.old, tc.new); got != tc.want {
+				t.Errorf("ldapGroupNameEquivalent(%q, %q, %q, %q) = %v, want %v",
+					tc.groupType, tc.ldapDN, tc.old, tc.new, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the three related bugs reported in #591 for `harbor_project_member_group` with `type = "ldap"`:

1. **Create fails with HTTP 500 and leaves an orphan usergroup.** Passing `member_group.ldap_group_dn` to `POST /api/v2.0/projects/{pid}/members` makes Harbor create the backing usergroup as a side effect and then 500 on the member attachment. On retry Harbor returns `LDAP user group with same DN already exist` and the resource is stuck.
2. **`group_name` drift forces replacement on every plan.** After the member exists in state (e.g. via `tofu import`), refresh reads the member back and Harbor returns the short group name instead of the DN the user put in config. The provider used to overwrite state with the short form, so the next plan showed a forced replace, which re-triggered bug #1.
3. **`type` is not read on refresh**, so after import the first plan shows a cosmetic `+ type = "ldap"` update.

## Fix

Single idea: **treat the backing Harbor usergroup as the source of truth**, and never pass `ldap_group_dn` to the members endpoint.

### `client/` — new usergroup helpers

- `GroupTypeLDAP/Internal/OIDC` constants and `GroupTypeName` as the inverse of the existing `GroupType`.
- `Client.ListGroups` (paginated), `GetGroupByID`, `CreateGroup`.
- `ResolveOrCreateLdapGroup(dn, name)` — case-insensitive DN lookup against `/usergroups`, creates on miss, retries the lookup on create conflict so two concurrent applies for the same DN converge without duplicates.
- `ShortNameFromDN`, `LooksLikeDN` helpers for back-compat.

### `client/project_members.go` — member body by id

`ProjectMembersGroupBody(d)` is replaced with `ProjectMembersGroupBodyByID(role, groupID)`. The new signature makes it impossible to emit `group_type`, `group_name` or `ldap_group_dn` into the members POST body — the exact shape that triggers the 500 is now unrepresentable at the type level.

### `models/project_members.go` — parse `entity_id`

Harbor returns `entity_id` on `GET /projects/{pid}/members/{mid}` but the model silently stripped it. Adding the field lets Read locate the backing usergroup directly instead of guessing from `entity_name`.

### `provider/resource_project_member_group.go`

- **Create:** `resolveMemberGroupID` resolves `group_id` / `ldap_group_dn` / `group_name` (back-compat DN detection via `LooksLikeDN`) to a concrete usergroup id, then POSTs the member with `{role_id, member_group: {id}}` only. For `internal`/`oidc` it looks the group up by name and fails loudly if missing.
- **Read:** for `entity_type == "g"` fetches the backing usergroup by `entity_id` and writes `type`, `group_name`, `ldap_group_dn` and `group_id` from it. Falls back to the old best-effort path if a Harbor version omits `entity_id`.
- **Update:** PUTs only `role_id`. Everything else is ForceNew or derived.
- **`DiffSuppressFunc` on `group_name`** (`ldapGroupNameEquivalent`) — collapses the spurious diff between a DN on one side and its first-RDN short form on the other, so existing state with a DN in `group_name` upgrades to a clean `plan` instead of a destructive replace. Pure-function core is covered by a table-driven unit test with positive, negative and non-LDAP cases.
- **Schema:** `type` becomes ForceNew (changing the group type really does need a new member entry); `group_name`, `group_id`, `ldap_group_dn` become Optional+Computed without ForceNew so values derived from the backing usergroup can be written back to state without a replace. `AtLeastOneOf` now also accepts `ldap_group_dn` as a sole input.

### Lifecycle policy

The backing usergroup is **never deleted on resource destroy**. It may be shared across projects and its lifecycle is independent — the resource only manages the project membership link. Documented explicitly in `docs/resources/project_member_group.md`.

## Tests

- **Unit** (`client/group_test.go`): `GroupType`↔`GroupTypeName` round-trip, `LooksLikeDN`, `ShortNameFromDN`, body-shape assertion on `ProjectMembersGroupBodyByID` that explicitly rejects any leakage of `ldap_group_dn`/`group_name`/`group_type`, and `ResolveOrCreateLdapGroup` against an `httptest` fake covering adopt, create-with-name-derived-from-DN, and empty-DN paths. `GetGroupByID` covered separately.
- **Unit** (`provider/resource_project_member_group_unit_test.go`): 9 cases for `ldapGroupNameEquivalent` covering both directions of DN↔short suppression, identical values, unrelated names, and negatives for `internal`/`oidc` and missing DN.
- **Existing acceptance** (`resource_project_member_group_test.go` under `//go:build external_auth`) still compiles and was not touched.
- `go vet` and `golangci-lint run` are clean on all touched files.

## Manual verification on a live Harbor

Verified end-to-end against a real Harbor instance with LDAP configured, using a dev_overrides build of the provider and OpenTofu:

| Scenario | Result |
|---|---|
| Create with `ldap_group_dn` (adopt existing usergroup) | project + member created, no 500 |
| `plan` after apply | `No changes` — bug #2 and bug #3 gone |
| `state rm` + `import` + `plan` | `No changes` — clean import |
| `role: developer → guest` | in-place update, no replace |
| `destroy` | member + project removed; backing usergroup preserved |
| Back-compat: DN in `group_name`, no `ldap_group_dn` | apply succeeds, `plan` after apply clean (DiffSuppressFunc works) |
| Two resources in two projects sharing one DN | both adopt the same usergroup id, no duplicates |
| Create with a DN not present in LDAP | Harbor itself rejects with `400 LDAP Group DN is not found`, error is surfaced correctly |

## Test plan for reviewers

- [ ] `go build ./...`
- [ ] `go test ./...`
- [ ] `go test -tags external_auth -run ^NONE$ ./...` (acceptance test compilation)
- [ ] Upgrade smoke: apply an old-shape config (`group_name = "cn=...,dc=..."`, no `ldap_group_dn`) against an older provider, switch to this build, confirm first `plan` is clean.
- [ ] Fresh apply with `ldap_group_dn`, then `import`, then `plan` — expect no diff.


Closes #591
