### PR TITLE
feat: add proxy_cache_local_on_not_found support for proxy cache projects

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -41,6 +41,7 @@ func ProjectBody(d *schema.ResourceData) models.ProjectsBodyPost {
 	body.Metadata.EnableContentTrustCosign = strconv.FormatBool(d.Get("enable_content_trust_cosign").(bool))
 	body.Metadata.AutoSbomGeneration = strconv.FormatBool(d.Get("auto_sbom_generation").(bool))
 	body.Metadata.ProxySpeedKb = strconv.Itoa(d.Get("proxy_speed_kb").(int))
+	body.Metadata.ProxyCacheLocalOnNotFound = strconv.FormatBool(d.Get("proxy_cache_local_on_not_found").(bool))
 
 	cveAllowList := d.Get("cve_allowlist").([]interface{})
 	log.Printf("[DEBUG] %v ", cveAllowList)

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -63,6 +63,7 @@ resource "harbor_registry" "docker" {
 ### Specific for Proxy Project
 - `registry_id` (Number) To enable project as Proxy Cache.
 - `proxy_speed_kb` (Number) Proxy max speed KB (Default: `-1`)
+- `proxy_cache_local_on_not_found` (Boolean) When enabled, serve images from the local cache when they have been removed from the upstream registry. (Default: `false`) Requires Harbor `v2.15.1` or above.
 
 ### Read-Only
 

--- a/models/projects.go
+++ b/models/projects.go
@@ -17,15 +17,16 @@ type ProjectsBodyPost struct {
 	} `json:"cve_allowlist,omitempty"`
 	StorageLimit int `json:"storage_limit,omitempty"`
 	Metadata     struct {
-		EnableContentTrust       string `json:"enable_content_trust,omitempty"`
-		EnableContentTrustCosign string `json:"enable_content_trust_cosign,omitempty"`
-		AutoScan                 string `json:"auto_scan,omitempty"`
-		Severity                 string `json:"severity,omitempty"`
-		ReuseSysCveAllowlist     string `json:"reuse_sys_cve_allowlist,omitempty"`
-		Public                   string `json:"public,omitempty"`
-		PreventVul               string `json:"prevent_vul,omitempty"`
-		AutoSbomGeneration       string `json:"auto_sbom_generation,omitempty"`
-		ProxySpeedKb             string `json:"proxy_speed_kb,omitempty"`
+		EnableContentTrust        string `json:"enable_content_trust,omitempty"`
+		EnableContentTrustCosign  string `json:"enable_content_trust_cosign,omitempty"`
+		AutoScan                  string `json:"auto_scan,omitempty"`
+		Severity                  string `json:"severity,omitempty"`
+		ReuseSysCveAllowlist      string `json:"reuse_sys_cve_allowlist,omitempty"`
+		Public                    string `json:"public,omitempty"`
+		PreventVul                string `json:"prevent_vul,omitempty"`
+		AutoSbomGeneration        string `json:"auto_sbom_generation,omitempty"`
+		ProxySpeedKb              string `json:"proxy_speed_kb,omitempty"`
+		ProxyCacheLocalOnNotFound string `json:"proxy_cache_local_on_not_found,omitempty"`
 	} `json:"metadata,omitempty"`
 }
 
@@ -52,16 +53,17 @@ type ProjectsBodyResponses struct {
 		ExpiresAt int `json:"expires_at"`
 	} `json:"cve_allowlist"`
 	Metadata struct {
-		EnableContentTrust       string `json:"enable_content_trust,omitempty"`
-		EnableContentTrustCosign string `json:"enable_content_trust_cosign,omitempty"`
-		AutoScan                 string `json:"auto_scan,omitempty"`
-		Severity                 string `json:"severity"`
-		ReuseSysCveAllowlist     string `json:"reuse_sys_cve_allowlist"`
-		Public                   string `json:"public"`
-		PreventVul               string `json:"prevent_vul"`
-		RetentionId              string `json:"retention_id"`
-		AutoSbomGeneration       string `json:"auto_sbom_generation,omitempty"`
-		ProxySpeedKb             string `json:"proxy_speed_kb,omitempty"`
+		EnableContentTrust        string `json:"enable_content_trust,omitempty"`
+		EnableContentTrustCosign  string `json:"enable_content_trust_cosign,omitempty"`
+		AutoScan                  string `json:"auto_scan,omitempty"`
+		Severity                  string `json:"severity"`
+		ReuseSysCveAllowlist      string `json:"reuse_sys_cve_allowlist"`
+		Public                    string `json:"public"`
+		PreventVul                string `json:"prevent_vul"`
+		RetentionId               string `json:"retention_id"`
+		AutoSbomGeneration        string `json:"auto_sbom_generation,omitempty"`
+		ProxySpeedKb              string `json:"proxy_speed_kb,omitempty"`
+		ProxyCacheLocalOnNotFound string `json:"proxy_cache_local_on_not_found,omitempty"`
 	} `json:"metadata"`
 }
 

--- a/provider/resource_project.go
+++ b/provider/resource_project.go
@@ -95,6 +95,11 @@ func resourceProject() *schema.Resource {
 				Optional: true,
 				Default:  -1,
 			},
+			"proxy_cache_local_on_not_found": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 		Create: resourceProjectCreate,
 		Read:   resourceProjectRead,
@@ -108,9 +113,13 @@ func resourceProject() *schema.Resource {
 
 func validateProjectProxy(d *schema.ResourceData) error {
 	speed := d.Get("proxy_speed_kb").(int)
+	localOnNotFound := d.Get("proxy_cache_local_on_not_found").(bool)
 	registryID := d.Get("registry_id").(int)
 	if speed != -1 && registryID == 0 {
 		return fmt.Errorf("'proxy_speed_kb' can only be used when 'registry_id' is set (proxy project)")
+	}
+	if localOnNotFound && registryID == 0 {
+		return fmt.Errorf("'proxy_cache_local_on_not_found' can only be used when 'registry_id' is set (proxy project)")
 	}
 	return nil
 }
@@ -216,6 +225,11 @@ func resourceProjectRead(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
+	proxyCacheLocalOnNotFound, err := client.ParseBoolOrDefault(jsonData.Metadata.ProxyCacheLocalOnNotFound, false)
+	if err != nil {
+		return err
+	}
+
 	d.Set("name", jsonData.Name)
 	d.Set("project_id", jsonData.ProjectID)
 	d.Set("registry_id", jsonData.RegistryID)
@@ -225,6 +239,7 @@ func resourceProjectRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("enable_content_trust_cosign", trustCosign)
 	d.Set("auto_sbom_generation", autoSbomGeneration)
 	d.Set("proxy_speed_kb", proxySpeedKb)
+	d.Set("proxy_cache_local_on_not_found", proxyCacheLocalOnNotFound)
 
 	cveAllowlist := make([]string, len(jsonData.CveAllowlist.Items))
 	for i, item := range jsonData.CveAllowlist.Items {


### PR DESCRIPTION
## What changed

- Added `proxy_cache_local_on_not_found` boolean attribute to the `harbor_project` resource
- When enabled, Harbor serves images from the local cache if they have been removed from the upstream registry
- Validation ensures the option can only be set on proxy cache projects (i.e. when `registry_id` is set)

## Why it changed

Harbor v2.15.1 introduced this capability via [goharbor/harbor#23049](https://github.com/goharbor/harbor/commit/3e57cea61f143e667413bfe9c24f673e0edab454). This adds Terraform support for the new project metadata field `proxy_cache_local_on_not_found`.

## How to test it

1. Configure a proxy cache project with a registry:
   ```hcl
   resource "harbor_project" "proxy" {
     name        = "proxy-test"
     registry_id = harbor_registry.main.registry_id

     proxy_cache_local_on_not_found = true
   }
   ```
2. Apply and verify the project metadata in Harbor UI or via the API (`GET /projects/{id}`) — `proxy_cache_local_on_not_found` should be `"true"`.
3. Verify that setting `proxy_cache_local_on_not_found = true` without `registry_id` produces a plan-time error.

> **Requires Harbor v2.15.1 or above.**

---
<sub>The changes and/or the PR description has been generated with the help of OpenCode.</sub>