### PR TITLE
feat: Add write-only OIDC client secret for config auth

### DIFF
--- a/docs/resources/config_auth.md
+++ b/docs/resources/config_auth.md
@@ -28,6 +28,25 @@ resource "harbor_config_auth" "oidc" {
 }
 ```
 
+### OIDC with Write-only Client Secret
+
+```terraform
+resource "harbor_config_auth" "oidc" {
+  auth_mode                     = "oidc_auth"
+  primary_auth_mode             = true
+  oidc_name                     = "azure"
+  oidc_endpoint                 = "https://login.microsoftonline.com/{GUID goes here}/v2.0"
+  oidc_client_id                = "OIDC Client ID goes here"
+  oidc_client_secret_wo         = "OIDC Client Secret goes here"
+  oidc_client_secret_wo_version = 1
+  oidc_scope                    = "openid,email"
+  oidc_verify_cert              = true
+  oidc_auto_onboard             = true
+  oidc_user_claim               = "name"
+  oidc_admin_group              = "administrators"
+}
+```
+
 ### LDAP
 
 ```terraform
@@ -53,10 +72,10 @@ resource "harbor_config_auth" "ldap" {
 
 ### Required, OIDC
 
-The following are required if `auth_mode` is `oidc_auth`
+The following are required if `auth_mode` is `oidc_auth`. Configure either `oidc_client_secret` or `oidc_client_secret_wo` together with `oidc_client_secret_wo_version`.
 
 - `oidc_client_id` (String) The client id for the oidc server.
-- `oidc_client_secret` (String, Sensitive) The client secert for the oidc server.
+- `oidc_client_secret` (String, Sensitive) The client secret for the oidc server.
 - `oidc_endpoint` (String) The URL of an OIDC-complaint server.
 - `oidc_name` (String) The name of the oidc provider name.
 - `oidc_scope` (String) The scope sent to OIDC server during authentication. It has to contain `“openid”`.
@@ -70,6 +89,8 @@ The following are required if `auth_mode` is `oidc_auth`
 - `oidc_groups_claim` (String) The name of the claim in the token whose values is the list of group names.
 - `oidc_user_claim` (String) Default is `name`
 - `oidc_logout` (Boolean) Set to `true` if you want to enable OIDC Session Logout (Default: `false`) can only be used with Harbor version v2.13 and above
+- `oidc_client_secret_wo` (String, Write-only) Write-only alternative for `oidc_client_secret`. Must be used together with `oidc_client_secret_wo_version`.
+- `oidc_client_secret_wo_version` (Number) Rotation trigger for write-only OIDC client secret updates. Must be used together with `oidc_client_secret_wo`.
 
 ### Required, LDAP
 

--- a/provider/resource_config_auth.go
+++ b/provider/resource_config_auth.go
@@ -5,11 +5,16 @@ import (
 
 	"github.com/goharbor/terraform-provider-harbor/client"
 	"github.com/goharbor/terraform-provider-harbor/models"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceConfigAuth() *schema.Resource {
 	return &schema.Resource{
+		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
+			validation.PreferWriteOnlyAttribute(cty.GetAttrPath("oidc_client_secret"), cty.GetAttrPath("oidc_client_secret_wo")),
+		},
 		Schema: map[string]*schema.Schema{
 			"auth_mode": {
 				Type:     schema.TypeString,
@@ -43,7 +48,28 @@ func resourceConfigAuth() *schema.Resource {
 				Optional:      true,
 				Sensitive:     true,
 				RequiredWith:  oidcRequiredWith(),
-				ConflictsWith: oidcConflictsWith(),
+				ConflictsWith: append(oidcConflictsWith(), "oidc_client_secret_wo", "oidc_client_secret_wo_version"),
+			},
+			"oidc_client_secret_wo": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				WriteOnly: true,
+				RequiredWith: append(oidcRequiredWith(),
+					"oidc_client_secret_wo_version",
+				),
+				ConflictsWith: append(oidcConflictsWith(),
+					"oidc_client_secret",
+				),
+			},
+			"oidc_client_secret_wo_version": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				RequiredWith: []string{
+					"oidc_client_secret_wo",
+				},
+				ConflictsWith: []string{
+					"oidc_client_secret",
+				},
 			},
 			"oidc_group_filter": {
 				Type:          schema.TypeString,
@@ -181,14 +207,42 @@ func resourceConfigAuth() *schema.Resource {
 func resourceConfigAuthCreate(d *schema.ResourceData, m interface{}) error {
 	apiClient := m.(*client.Client)
 
-	body := client.GetConfigAuth(d)
+	body, err := getConfigAuthBody(d)
+	if err != nil {
+		return err
+	}
 
-	_, _, _, err := apiClient.SendRequest("PUT", models.PathConfig, body, 200)
+	_, _, _, err = apiClient.SendRequest("PUT", models.PathConfig, body, 200)
 	if err != nil {
 		return err
 	}
 
 	return resourceConfigAuthRead(d, m)
+}
+
+func getConfigAuthBody(d *schema.ResourceData) (models.ConfigBodyAuthPost, error) {
+	return getConfigAuthBodyWithWriteOnly(d, getWriteOnlyString)
+}
+
+func getConfigAuthBodyWithWriteOnly(d *schema.ResourceData, getWriteOnly func(*schema.ResourceData, string) (string, error)) (models.ConfigBodyAuthPost, error) {
+	body := client.GetConfigAuth(d)
+	if body.AuthMode != "oidc_auth" {
+		return body, nil
+	}
+
+	oidcClientSecretWriteOnly, err := getWriteOnly(d, "oidc_client_secret_wo")
+	if err != nil {
+		return body, err
+	}
+	if oidcClientSecretWriteOnly != "" {
+		body.OidcClientSecret = oidcClientSecretWriteOnly
+	}
+
+	if body.OidcClientSecret == "" {
+		return body, fmt.Errorf("one of oidc_client_secret or oidc_client_secret_wo must be configured")
+	}
+
+	return body, nil
 }
 
 func resourceConfigAuthRead(d *schema.ResourceData, m interface{}) error {
@@ -230,11 +284,11 @@ func oidcConflictsWith() []string {
 }
 
 func oidcRequiredWith() []string {
-	return []string{"oidc_name", "oidc_endpoint", "oidc_client_id", "oidc_client_secret", "oidc_scope"}
+	return []string{"oidc_name", "oidc_endpoint", "oidc_client_id", "oidc_scope"}
 }
 
 func ldapConflictsWith() []string {
-	return []string{"oidc_name", "oidc_endpoint", "oidc_client_id", "oidc_client_secret", "oidc_groups_claim", "oidc_scope", "oidc_verify_cert", "oidc_auto_onboard", "oidc_user_claim"}
+	return []string{"oidc_name", "oidc_endpoint", "oidc_client_id", "oidc_client_secret", "oidc_client_secret_wo", "oidc_client_secret_wo_version", "oidc_groups_claim", "oidc_scope", "oidc_verify_cert", "oidc_auto_onboard", "oidc_user_claim"}
 }
 
 func ldapRequiredWith() []string {

--- a/provider/resource_config_auth_test.go
+++ b/provider/resource_config_auth_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/goharbor/terraform-provider-harbor/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -22,6 +23,74 @@ func getLdapURL() string {
 }
 
 const resourceConfigAuthMain = "harbor_config_auth.main"
+
+func TestGetConfigAuthBodyOIDCClientSecret(t *testing.T) {
+	d := testConfigAuthResourceData(t, map[string]interface{}{
+		"auth_mode":          "oidc_auth",
+		"oidc_name":          "azure",
+		"oidc_endpoint":      "https://login.microsoftonline.com/example/v2.0",
+		"oidc_client_id":     "harbor",
+		"oidc_client_secret": "legacy-secret",
+		"oidc_scope":         "openid,email",
+	})
+
+	body, err := getConfigAuthBodyWithWriteOnly(d, testEmptyWriteOnlyString)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if body.OidcClientSecret != "legacy-secret" {
+		t.Fatalf("unexpected oidc client secret: got %q", body.OidcClientSecret)
+	}
+}
+
+func TestGetConfigAuthBodyOIDCClientSecretWriteOnly(t *testing.T) {
+	d := testConfigAuthResourceData(t, map[string]interface{}{
+		"auth_mode":                     "oidc_auth",
+		"oidc_name":                     "azure",
+		"oidc_endpoint":                 "https://login.microsoftonline.com/example/v2.0",
+		"oidc_client_id":                "harbor",
+		"oidc_client_secret_wo":         "write-only-secret",
+		"oidc_client_secret_wo_version": 1,
+		"oidc_scope":                    "openid,email",
+	})
+
+	body, err := getConfigAuthBodyWithWriteOnly(d, func(d *schema.ResourceData, key string) (string, error) {
+		return "write-only-secret", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if body.OidcClientSecret != "write-only-secret" {
+		t.Fatalf("unexpected oidc client secret: got %q", body.OidcClientSecret)
+	}
+}
+
+func TestGetConfigAuthBodyRequiresOIDCClientSecret(t *testing.T) {
+	d := testConfigAuthResourceData(t, map[string]interface{}{
+		"auth_mode":      "oidc_auth",
+		"oidc_name":      "azure",
+		"oidc_endpoint":  "https://login.microsoftonline.com/example/v2.0",
+		"oidc_client_id": "harbor",
+		"oidc_scope":     "openid,email",
+	})
+
+	_, err := getConfigAuthBodyWithWriteOnly(d, testEmptyWriteOnlyString)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}
+
+func testConfigAuthResourceData(t *testing.T, raw map[string]interface{}) *schema.ResourceData {
+	t.Helper()
+
+	return schema.TestResourceDataRaw(t, resourceConfigAuth().Schema, raw)
+}
+
+func testEmptyWriteOnlyString(d *schema.ResourceData, key string) (string, error) {
+	return "", nil
+}
 
 func testAccCheckConfigAuthDestroy(s *terraform.State) error {
 	apiClient := testAccProvider.Meta().(*client.Client)
@@ -120,6 +189,48 @@ func TestAccConfigAuthLdap(t *testing.T) {
 	})
 }
 
+func TestAccConfigAuthOIDCWriteOnlyClientSecret(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckConfigAuthDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckConfigAuthOIDCWriteOnlyClientSecret(1, "write-only-secret"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceExists(resourceConfigAuthMain),
+					resource.TestCheckResourceAttr(
+						resourceConfigAuthMain, "auth_mode", "oidc_auth"),
+					resource.TestCheckResourceAttr(
+						resourceConfigAuthMain, "oidc_client_secret_wo_version", "1"),
+					resource.TestCheckNoResourceAttr(
+						resourceConfigAuthMain, "oidc_client_secret_wo"),
+				),
+			},
+			{
+				Config: testAccCheckConfigAuthOIDCWriteOnlyClientSecret(2, "write-only-secret-rotated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceExists(resourceConfigAuthMain),
+					resource.TestCheckResourceAttr(
+						resourceConfigAuthMain, "auth_mode", "oidc_auth"),
+					resource.TestCheckResourceAttr(
+						resourceConfigAuthMain, "oidc_client_secret_wo_version", "2"),
+					resource.TestCheckNoResourceAttr(
+						resourceConfigAuthMain, "oidc_client_secret_wo"),
+				),
+			},
+			{
+				Config: testAccCheckConfigAuthLdapMain(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceExists(resourceConfigAuthMain),
+					resource.TestCheckResourceAttr(
+						resourceConfigAuthMain, "auth_mode", "ldap_auth"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckConfigAuthLdap() string {
 	ldapURL := getLdapURL()
 	return fmt.Sprintf(`
@@ -140,6 +251,45 @@ func testAccCheckConfigAuthLdap() string {
 		ldap_group_scope      = "subtree"
 	}
 	`, ldapURL)
+}
+
+func testAccCheckConfigAuthOIDCWriteOnlyClientSecret(version int, secret string) string {
+	return fmt.Sprintf(`
+		resource "harbor_config_auth" "main" {
+			auth_mode                     = "oidc_auth"
+			oidc_name                     = "codex-oidc"
+			oidc_endpoint                 = "https://oidc.example.com"
+			oidc_client_id                = "harbor"
+			oidc_client_secret_wo         = "%s"
+			oidc_client_secret_wo_version = %d
+			oidc_scope                    = "openid,email"
+			oidc_verify_cert              = false
+			oidc_auto_onboard             = true
+			oidc_user_claim               = "name"
+		}
+		`, secret, version)
+}
+
+func testAccCheckConfigAuthLdapMain() string {
+	ldapURL := getLdapURL()
+	return fmt.Sprintf(`
+		resource "harbor_config_auth" "main" {
+			auth_mode            = "ldap_auth"
+			ldap_url             = "%s"
+			ldap_base_dn         = "ou=people,dc=planetexpress,dc=com"
+			ldap_uid             = "uid"
+			ldap_verify_cert     = false
+			ldap_search_dn       = "cn=admin,dc=planetexpress,dc=com"
+			ldap_search_password = "GoodNewsEveryone"
+			ldap_scope           = "onelevel"
+			ldap_group_base_dn   = "ou=people,dc=planetexpress,dc=com"
+			ldap_group_filter    = "(objectClass=posixGroup)"
+			ldap_group_gid       = "cn"
+			ldap_group_admin_dn  = "cn=admin_staff,ou=people,dc=planetexpress,dc=com"
+			ldap_group_membership = "memberof"
+			ldap_group_scope     = "subtree"
+		}
+		`, ldapURL)
 }
 
 // ─── harbor_group LDAP tests ───────────────────────────────────────────────


### PR DESCRIPTION
Closes #605

Adds write-only OIDC client secret support for harbor_config_auth:
- oidc_client_secret_wo
- oidc_client_secret_wo_version
- validation matching existing write-only resource patterns
- unit and acceptance coverage
- documentation example