### PR TITLE
feat: allow custom HTTP headers on the provider

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -21,10 +21,11 @@ type Client struct {
 	insecure    bool
 	httpClient  *http.Client
 	robotPrefix string
+	headers     map[string]string
 }
 
 // NewClient creates common settings
-func NewClient(url string, username string, password string, sessionId string, bearerToken string, insecure bool, robotPrefix string) *Client {
+func NewClient(url string, username string, password string, sessionId string, bearerToken string, insecure bool, robotPrefix string, headers map[string]string) *Client {
 	return &Client{
 		url:         url,
 		username:    username,
@@ -34,6 +35,7 @@ func NewClient(url string, username string, password string, sessionId string, b
 		insecure:    insecure,
 		httpClient:  &http.Client{},
 		robotPrefix: robotPrefix,
+		headers:     headers,
 	}
 }
 
@@ -73,6 +75,18 @@ func (c *Client) sendRequestWithHeaders(method string, path string, payload inte
 	}
 
 	req.Header.Add("Content-Type", "application/json")
+
+	// Apply custom headers configured on the provider to every request. A
+	// "Host" header must be set on req.Host, as Go ignores a Host entry placed
+	// in req.Header.
+	for header, value := range c.headers {
+		if strings.EqualFold(header, "host") {
+			req.Host = value
+		} else {
+			req.Header.Set(header, value)
+		}
+	}
+
 	for header, values := range extraHeaders {
 		for _, value := range values {
 			req.Header.Add(header, value)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,8 +3,37 @@ package client
 import (
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 )
+
+func TestSendRequestCustomHeaders(t *testing.T) {
+	var gotHeader string
+	var gotHost string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("X-Custom-Header")
+		gotHost = r.Host
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, "user", "pass", "", "", false, "", map[string]string{
+		"X-Custom-Header": "custom-value",
+		"Host":            "waf.example.com",
+	})
+
+	_, _, _, err := c.SendRequest("GET", "", nil, http.StatusOK)
+	if err != nil {
+		t.Fatalf("got unexpected error: %v", err)
+	}
+
+	if gotHeader != "custom-value" {
+		t.Fatalf("X-Custom-Header was %q; want %q", gotHeader, "custom-value")
+	}
+	if gotHost != "waf.example.com" {
+		t.Fatalf("Host was %q; want %q", gotHost, "waf.example.com")
+	}
+}
 
 func TestExtractCsrfHeaders(t *testing.T) {
 	var testCases = []struct {

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ description: |-
 
 - `api_version` (Number) Choose which version of the API you would like to use 1 or 2 (default is 2)
 - `bearer_token` (String) The bearer token to be used to access harbor. Will take precedence over username and password if set
+- `headers` (Map of String, Sensitive) A map of custom HTTP headers to append to every API request. Useful for passing traffic through a WAF or proxy. A `Host` entry sets the request Host.
 - `session_id` (String) The session ID cookie (`sid`) when using OAuth/OIDC. Can be provided via `HARBOR_SESSION_ID`. Will take precedence over `bearer_token` if set. Note that OAuth/OIDC support is experimental and will be deprecated and removed if harbor provides a better way to authenticate with its API
 - `insecure` (Boolean) Ignore certificate errors, switching it to `false` is recommended (default: true)
 - `robot_prefix` (String) Without this option, the provider will try to automatically determine the robot prefix with a call to the admin API. If you don't have admin access and want to create system robot account, you'll have to set this value.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ description: |-
 
 - `api_version` (Number) Choose which version of the API you would like to use 1 or 2 (default is 2)
 - `bearer_token` (String) The bearer token to be used to access harbor. Will take precedence over username and password if set
-- `headers` (Map of String, Sensitive) A map of custom HTTP headers to append to every API request. Useful for passing traffic through a WAF or proxy. A `Host` entry sets the request Host.
+- `headers` (Map of String, Sensitive) A map of custom HTTP headers to set on every API request. Each header overwrites any existing header of the same name. Useful for passing traffic through a WAF or proxy. A `Host` entry sets the request Host.
 - `session_id` (String) The session ID cookie (`sid`) when using OAuth/OIDC. Can be provided via `HARBOR_SESSION_ID`. Will take precedence over `bearer_token` if set. Note that OAuth/OIDC support is experimental and will be deprecated and removed if harbor provides a better way to authenticate with its API
 - `insecure` (Boolean) Ignore certificate errors, switching it to `false` is recommended (default: true)
 - `robot_prefix` (String) Without this option, the provider will try to automatically determine the robot prefix with a call to the admin API. If you don't have admin access and want to create system robot account, you'll have to set this value.

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -53,6 +53,13 @@ func Provider() *schema.Provider {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"headers": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Sensitive:   true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "A map of custom HTTP headers to append to every API request. Useful for passing traffic through a WAF or proxy. A `Host` entry sets the request Host.",
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -112,6 +119,11 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	apiVersion := d.Get("api_version").(int)
 	robotPrefix := d.Get("robot_prefix").(string)
 
+	headers := make(map[string]string)
+	for k, v := range d.Get("headers").(map[string]interface{}) {
+		headers[k] = v.(string)
+	}
+
 	if strings.HasSuffix(url, "/") {
 		url = strings.Trim(url, "/")
 	}
@@ -122,5 +134,5 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		apiPath = "/api/v2.0"
 	}
 
-	return client.NewClient(url+apiPath, username, password, sessionId, bearerToken, insecure, robotPrefix), nil
+	return client.NewClient(url+apiPath, username, password, sessionId, bearerToken, insecure, robotPrefix, headers), nil
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -58,7 +58,7 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Sensitive:   true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: "A map of custom HTTP headers to append to every API request. Useful for passing traffic through a WAF or proxy. A `Host` entry sets the request Host.",
+				Description: "A map of custom HTTP headers to set on every API request. Each header overwrites any existing header of the same name. Useful for passing traffic through a WAF or proxy. A `Host` entry sets the request Host.",
 			},
 		},
 


### PR DESCRIPTION
Adds an optional `headers` map on the provider config, applied to every Harbor API request. This lets users reach a Harbor instance behind a WAF or proxy that requires a custom header, without maintaining a fork.

```hcl
provider "harbor" {
  url = "https://harbor.example.com"
  headers = {
    "X-WAF-Token" = "secret"
  }
}
```

The map is marked `Sensitive` (header values are often secrets). A `Host` entry sets the request `Host` rather than a header, since Go ignores a `Host` value placed in `req.Header`. Headers are applied in the client's single request choke point, so the CSRF-retry path is covered too.

The approach mirrors the GitLab provider's `headers` attribute.

Closes #318
